### PR TITLE
feat: add company and bot group for PR/contributor metrics

### DIFF
--- a/configs/dev/grafana/chaosmesh/custom_sqlite.sql
+++ b/configs/dev/grafana/chaosmesh/custom_sqlite.sql
@@ -109,7 +109,9 @@ set
   )
 where
   slug in (
-    'new-prs-in-repository-groups',
+    'prs-opened-in-repository-groups',
+    'prs-merged-in-repository-groups',
+    'prs-closed-in-repository-groups',
     'open-pr-age-by-repository-group',
     'opened-to-merged',
     'pr-reviews-by-contributor',
@@ -117,7 +119,6 @@ where
     'prs-approval-repository-groups',
     'prs-authors-repository-groups',
     'prs-authors-table',
-    'prs-merged-repository-groups',
     'prs-mergers-table',
     'time-to-merge-in-repository-groups'
   )

--- a/configs/dev/grafana/dashboards/chaosmesh/dashboards.json
+++ b/configs/dev/grafana/dashboards/chaosmesh/dashboards.json
@@ -32,7 +32,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 15,
-  "iteration": 1622080154256,
+  "iteration": 1622359473216,
   "links": [
     {
       "icon": "dashboard",
@@ -234,7 +234,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
+        "h": 19,
         "w": 12,
         "x": 0,
         "y": 6
@@ -352,7 +352,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 17,
+        "h": 19,
         "w": 12,
         "x": 12,
         "y": 18
@@ -414,7 +414,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 25
       },
       "id": 8,
       "options": {
@@ -473,7 +473,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 37
       },
       "id": 18,
       "options": {
@@ -528,10 +528,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 37
       },
       "id": 14,
       "options": {
@@ -589,10 +589,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 45
       },
       "id": 16,
       "options": {
@@ -648,10 +648,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 12,
         "x": 12,
-        "y": 49
+        "y": 53
       },
       "id": 4,
       "links": [],
@@ -687,7 +687,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 57
       },
       "id": 6,
       "links": [],
@@ -714,8 +714,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"-full_name-home-dashboard\">ChaosMesh Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://devstats-dev.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/chaosmesh/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://chaosmesh-devstats-dev.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for ChaosMesh project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for ChaosMesh project.</li>\n</ul>",
-          "value": "<h1 id=\"-full_name-home-dashboard\">ChaosMesh Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://devstats-dev.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/chaosmesh/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://chaosmesh-devstats-dev.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for ChaosMesh project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for ChaosMesh project.</li>\n</ul>"
+          "text": "<h1 id=\"-full_name-home-dashboard\">ChaosMesh Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://dev.devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/chaosmesh/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://chaosmesh.dev.devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for ChaosMesh project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for ChaosMesh project.</li>\n</ul>",
+          "value": "<h1 id=\"-full_name-home-dashboard\">ChaosMesh Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://dev.devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/chaosmesh/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://chaosmesh.dev.devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for ChaosMesh project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for ChaosMesh project.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -770,8 +770,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "devstats-dev.tidb.io",
-          "value": "devstats-dev.tidb.io"
+          "text": "dev.devstats.tidb.io",
+          "value": "dev.devstats.tidb.io"
         },
         "datasource": "psql",
         "definition": "",
@@ -829,5 +829,5 @@
   "timezone": "",
   "title": "Dashboards",
   "uid": "8",
-  "version": 2
+  "version": 3
 }

--- a/configs/dev/grafana/dashboards/chaosmesh/new-and-episodic-pr-contributors.json
+++ b/configs/dev/grafana/dashboards/chaosmesh/new-and-episodic-pr-contributors.json
@@ -30,8 +30,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 25,
-  "iteration": 1620638258918,
+  "id": 26,
+  "iteration": 1622353566135,
   "links": [],
   "panels": [
     {
@@ -273,7 +273,8 @@
   "tags": [
     "dashboard",
     "chaosmesh",
-    "issues"
+    "issues",
+    "active"
   ],
   "templating": {
     "list": [
@@ -281,8 +282,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "Chaos Mesh",
-          "value": "Chaos Mesh"
+          "text": "ChaosMesh",
+          "value": "ChaosMesh"
         },
         "datasource": "psql",
         "definition": "",
@@ -410,8 +411,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"dashboard-header\">Chaos Mesh new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
-          "value": "<h1 id=\"dashboard-header\">Chaos Mesh new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
+          "text": "<h1 id=\"dashboard-header\">ChaosMesh new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">ChaosMesh new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",

--- a/configs/dev/grafana/dashboards/chaosmesh/opened-to-merged.json
+++ b/configs/dev/grafana/dashboards/chaosmesh/opened-to-merged.json
@@ -31,7 +31,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 30,
-  "iteration": 1622080414825,
+  "iteration": 1622363662988,
   "links": [],
   "panels": [
     {
@@ -237,7 +237,7 @@
         },
         {
           "$$hashKey": "object:70",
-          "format": "short",
+          "format": "h",
           "label": "Opened to merged (15th percentile)",
           "logBase": 1,
           "max": null,
@@ -580,6 +580,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:76",
           "format": "h",
           "label": "Opened to merged (median & 85th percentile)",
           "logBase": 10,
@@ -588,12 +589,13 @@
           "show": true
         },
         {
+          "$$hashKey": "object:77",
           "format": "short",
           "label": "Opened to merged (15th percentile)",
           "logBase": 1,
           "max": null,
           "min": "0",
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
@@ -630,7 +632,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 39
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 13,
@@ -800,7 +802,7 @@
             },
             {
               "$$hashKey": "object:123",
-              "format": "short",
+              "format": "h",
               "label": "Opened to merged (15th percentile)",
               "logBase": 1,
               "max": null,
@@ -846,7 +848,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 40
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 14,
@@ -1016,7 +1018,7 @@
             },
             {
               "$$hashKey": "object:231",
-              "format": "short",
+              "format": "h",
               "label": "Opened to merged (15th percentile)",
               "logBase": 1,
               "max": null,
@@ -1270,5 +1272,5 @@
   "timezone": "",
   "title": "Opened to Merged",
   "uid": "16",
-  "version": 3
+  "version": 4
 }

--- a/configs/dev/grafana/dashboards/chaosmesh/prs-closed-in-repository-groups.json
+++ b/configs/dev/grafana/dashboards/chaosmesh/prs-closed-in-repository-groups.json
@@ -31,7 +31,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1007,
-  "iteration": 1622362680020,
+  "iteration": 1622365281282,
   "links": [],
   "panels": [
     {
@@ -671,7 +671,7 @@
   "style": "dark",
   "tags": [
     "dashboard",
-    "pingcap",
+    "chaosmesh",
     "active"
   ],
   "templating": {
@@ -680,8 +680,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "PingCAP",
-          "value": "PingCAP"
+          "text": "ChaosMesh",
+          "value": "ChaosMesh"
         },
         "datasource": "psql",
         "definition": "",
@@ -787,8 +787,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"dashboard-header\">PingCAP PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
-          "value": "<h1 id=\"dashboard-header\">PingCAP PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
+          "text": "<h1 id=\"dashboard-header\">ChaosMesh PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">ChaosMesh PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -877,7 +877,7 @@
     ]
   },
   "timezone": "",
-  "title": "PRs Closed Repository Groups",
+  "title": "PRs Closed in Repository Groups",
   "uid": "pr-closed",
-  "version": 12
+  "version": 13
 }

--- a/configs/dev/grafana/dashboards/chaosmesh/prs-closed-repository-groups.json
+++ b/configs/dev/grafana/dashboards/chaosmesh/prs-closed-repository-groups.json
@@ -30,10 +30,340 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 40,
-  "iteration": 1622359049509,
+  "id": 1007,
+  "iteration": 1622362680020,
   "links": [],
   "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "psql",
+          "decimals": 0,
+          "description": "The number of new pull requests closed in [[repogroup]] repository group.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 14,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 13,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.0",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "hide": false,
+              "measurement": "reviewers_d",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsistop')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            },
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "hide": false,
+              "measurement": "reviewers_d",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsnottop')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PRs closed ([[repogroup_name]], [[period]], exclude bots)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [
+              "total"
+            ]
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:333",
+              "format": "none",
+              "label": "New PRs",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:334",
+              "format": "none",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "psql",
+          "decimals": 0,
+          "description": "PRs closed in all [[full_name]] repositories",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 5,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.0",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "PRs merged",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "measurement": "all_prs_merged_h",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsallcompany')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PRs closed in all [[full_name]] repositories ([[period]])",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:551",
+              "format": "short",
+              "label": "PRs merged",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:552",
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "PR closed (Not include merged PR)",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 21,
+      "panels": [],
+      "title": "PR closed or merged ",
+      "type": "row"
+    },
     {
       "aliasColors": {},
       "bars": true,
@@ -41,7 +371,7 @@
       "dashes": false,
       "datasource": "psql",
       "decimals": 0,
-      "description": "Number of new pull requests merged in [[repogroup]] repository group.",
+      "description": "The number of pull requests closed or merged in [[repogroup]] repository group.",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -51,13 +381,13 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 15,
+        "h": 14,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 2
       },
       "hiddenSeries": false,
-      "id": 13,
+      "id": 16,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -101,7 +431,7 @@
           "policy": "autogen",
           "query": "",
           "rawQuery": true,
-          "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_merged_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_merged_company[[repogroup_name]]excludebotsistop')\n  and period = '[[period]]'\norder by\n  time",
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"The top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsistop')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsistop')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -137,7 +467,7 @@
           "policy": "autogen",
           "query": "",
           "rawQuery": true,
-          "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_merged_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_merged_company[[repogroup_name]]excludebotsnottop')\n  and period = '[[period]]'\norder by\n  time",
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"Not top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsnottop')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsnottop')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
           "refId": "B",
           "resultFormat": "time_series",
           "select": [
@@ -165,7 +495,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "PRs Merged ([[repogroup_name]], [[period]], exclude bots)",
+      "title": "PRs closed or merged ([[repogroup_name]], [[period]], exclude bots)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -213,7 +543,7 @@
       "dashes": false,
       "datasource": "psql",
       "decimals": 0,
-      "description": "PRs merged in all [[full_name]] repositories",
+      "description": "PRs closed or merged in all [[full_name]] repositories",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -224,10 +554,10 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 16
       },
       "hiddenSeries": false,
-      "id": 3,
+      "id": 17,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -268,7 +598,7 @@
           "policy": "default",
           "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
           "rawQuery": true,
-          "rawSql": "select\n  time,\n  \"value\" as \"All PRs merged\"\nfrom\n  sall_prs_merged\nwhere\n  $__timeFilter(time)\n  and period = '[[period]]'\norder by\n  time",
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"The top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsallcompany')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsallcompany')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -296,7 +626,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "PRs merged in all [[full_name]] repositories ([[period]])",
+      "title": "PRs closed or merged  in all [[full_name]] repositories ([[period]])",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -312,6 +642,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:551",
           "format": "short",
           "label": "PRs merged",
           "logBase": 1,
@@ -320,6 +651,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:552",
           "format": "short",
           "label": "",
           "logBase": 1,
@@ -332,28 +664,6 @@
         "align": false,
         "alignLevel": null
       }
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 27
-      },
-      "id": 11,
-      "links": [],
-      "options": {
-        "content": "${docs:raw}",
-        "mode": "html"
-      },
-      "pluginVersion": "7.5.0",
-      "title": "Dashboard documentation",
-      "type": "text"
     }
   ],
   "refresh": false,
@@ -567,7 +877,7 @@
     ]
   },
   "timezone": "",
-  "title": "PRs Merged Repository Groups",
-  "uid": "24",
+  "title": "PRs Closed Repository Groups",
+  "uid": "pr-closed",
   "version": 12
 }

--- a/configs/dev/grafana/dashboards/chaosmesh/prs-merged-in-repository-groups.json
+++ b/configs/dev/grafana/dashboards/chaosmesh/prs-merged-in-repository-groups.json
@@ -31,7 +31,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 40,
-  "iteration": 1622359049509,
+  "iteration": 1622365252513,
   "links": [],
   "panels": [
     {
@@ -361,7 +361,7 @@
   "style": "dark",
   "tags": [
     "dashboard",
-    "pingcap",
+    "chaosmesh",
     "active"
   ],
   "templating": {
@@ -370,8 +370,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "PingCAP",
-          "value": "PingCAP"
+          "text": "ChaosMesh",
+          "value": "ChaosMesh"
         },
         "datasource": "psql",
         "definition": "",
@@ -477,8 +477,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"dashboard-header\">PingCAP PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
-          "value": "<h1 id=\"dashboard-header\">PingCAP PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
+          "text": "<h1 id=\"dashboard-header\">ChaosMesh PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">ChaosMesh PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -567,7 +567,7 @@
     ]
   },
   "timezone": "",
-  "title": "PRs Merged Repository Groups",
+  "title": "PRs Merged in Repository Groups",
   "uid": "24",
-  "version": 12
+  "version": 13
 }

--- a/configs/dev/grafana/dashboards/chaosmesh/prs-opened-in-repository-groups.json
+++ b/configs/dev/grafana/dashboards/chaosmesh/prs-opened-in-repository-groups.json
@@ -30,8 +30,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 27,
-  "iteration": 1620625462005,
+  "id": 28,
+  "iteration": 1622359599936,
   "links": [],
   "panels": [
     {
@@ -51,10 +51,182 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 22,
+        "h": 14,
         "w": 24,
         "x": 0,
         "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_opened_company\nwhere\n  $__timeFilter(time)\n  and series = 'pr_opened_company[[repogroup]]excludebotsistop'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_opened_company\nwhere\n  $__timeFilter(time)\n  and series = 'pr_opened_company[[repogroup]]excludebotsnottop'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "New PRs created ([[repogroup_name]], [[period]], exclude bots)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:333",
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:334",
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "Number of new pull requests created in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 14
       },
       "hiddenSeries": false,
       "id": 1,
@@ -221,7 +393,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 29
       },
       "id": 11,
       "links": [],
@@ -239,16 +411,17 @@
   "style": "dark",
   "tags": [
     "dashboard",
-    "pingcap"
+    "chaosmesh",
+    "active"
   ],
   "templating": {
     "list": [
       {
         "allValue": null,
         "current": {
-          "tags": [],
-          "text": "Week",
-          "value": "w"
+          "selected": true,
+          "text": "7 Days MA",
+          "value": "d7"
         },
         "description": null,
         "error": null,
@@ -259,7 +432,7 @@
         "name": "period",
         "options": [
           {
-            "selected": false,
+            "selected": true,
             "text": "7 Days MA",
             "value": "d7"
           },
@@ -269,7 +442,7 @@
             "value": "d"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "Week",
             "value": "w"
           },
@@ -290,6 +463,7 @@
           }
         ],
         "query": "d,d7,w,m,q,y",
+        "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
       },
@@ -297,8 +471,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "PingCAP",
-          "value": "PingCAP"
+          "text": "ChaosMesh",
+          "value": "ChaosMesh"
         },
         "datasource": "psql",
         "definition": "",
@@ -381,8 +555,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"dashboard-header\">PingCAP new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
-          "value": "<h1 id=\"dashboard-header\">PingCAP new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
+          "text": "<h1 id=\"dashboard-header\">ChaosMesh new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">ChaosMesh new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -408,7 +582,7 @@
     ]
   },
   "time": {
-    "from": "now-1y",
+    "from": "now-90d",
     "to": "now"
   },
   "timepicker": {
@@ -437,7 +611,7 @@
     ]
   },
   "timezone": "",
-  "title": "New PRs in Repository Groups",
+  "title": "PRs Opened in Repository Groups",
   "uid": "15",
-  "version": 2
+  "version": 7
 }

--- a/configs/dev/grafana/dashboards/pingcap/dashboards.json
+++ b/configs/dev/grafana/dashboards/pingcap/dashboards.json
@@ -32,7 +32,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 15,
-  "iteration": 1622080154256,
+  "iteration": 1622359473216,
   "links": [
     {
       "icon": "dashboard",
@@ -234,7 +234,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
+        "h": 19,
         "w": 12,
         "x": 0,
         "y": 6
@@ -352,7 +352,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 17,
+        "h": 19,
         "w": 12,
         "x": 12,
         "y": 18
@@ -414,7 +414,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 25
       },
       "id": 8,
       "options": {
@@ -473,7 +473,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 37
       },
       "id": 18,
       "options": {
@@ -528,10 +528,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 37
       },
       "id": 14,
       "options": {
@@ -589,10 +589,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 45
       },
       "id": 16,
       "options": {
@@ -648,10 +648,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 12,
         "x": 12,
-        "y": 49
+        "y": 53
       },
       "id": 4,
       "links": [],
@@ -687,7 +687,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 57
       },
       "id": 6,
       "links": [],
@@ -714,8 +714,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"-full_name-home-dashboard\">PingCAP Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://devstats-dev.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/pingcap/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://pingcap-devstats-dev.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for PingCAP project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for PingCAP project.</li>\n</ul>",
-          "value": "<h1 id=\"-full_name-home-dashboard\">PingCAP Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://devstats-dev.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/pingcap/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://pingcap-devstats-dev.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for PingCAP project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for PingCAP project.</li>\n</ul>"
+          "text": "<h1 id=\"-full_name-home-dashboard\">PingCAP Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://dev.devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/pingcap/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://pingcap.dev.devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for PingCAP project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for PingCAP project.</li>\n</ul>",
+          "value": "<h1 id=\"-full_name-home-dashboard\">PingCAP Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://dev.devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/pingcap/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://pingcap.dev.devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for PingCAP project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for PingCAP project.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -770,8 +770,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "devstats-dev.tidb.io",
-          "value": "devstats-dev.tidb.io"
+          "text": "dev.devstats.tidb.io",
+          "value": "dev.devstats.tidb.io"
         },
         "datasource": "psql",
         "definition": "",
@@ -829,5 +829,5 @@
   "timezone": "",
   "title": "Dashboards",
   "uid": "8",
-  "version": 2
+  "version": 3
 }

--- a/configs/dev/grafana/dashboards/pingcap/new-and-episodic-pr-contributors.json
+++ b/configs/dev/grafana/dashboards/pingcap/new-and-episodic-pr-contributors.json
@@ -30,8 +30,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 20,
-  "iteration": 1533289967018,
+  "id": 26,
+  "iteration": 1622353566135,
   "links": [],
   "panels": [
     {
@@ -42,13 +42,19 @@
       "datasource": "psql",
       "decimals": 0,
       "description": "Displays the number of new/episodic issues and the number of new/episodic issues authors.\nThe episodic author is defined as someone who hasn't created issue in the last 3 months and no more than 12 issues overall.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 22,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 1,
       "legend": {
         "alignAsTable": false,
@@ -67,7 +73,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.0",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -192,6 +202,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "New/episodic issues ([[repogroup_name]], [[period]])",
       "tooltip": {
@@ -234,7 +245,11 @@
       }
     },
     {
-      "content": "${docs:raw}",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 13,
         "w": 24,
@@ -243,25 +258,37 @@
       },
       "id": 11,
       "links": [],
-      "mode": "html",
+      "options": {
+        "content": "${docs:raw}",
+        "mode": "html"
+      },
+      "pluginVersion": "7.5.0",
       "title": "Dashboard documentation",
       "type": "text"
     }
   ],
   "refresh": false,
-  "schemaVersion": 16,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "dashboard",
     "pingcap",
-    "issues"
+    "issues",
+    "active"
   ],
   "templating": {
     "list": [
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "PingCAP",
+          "value": "PingCAP"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -286,6 +313,8 @@
           "text": "28 Days MA",
           "value": "d28"
         },
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Period",
@@ -324,8 +353,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Repository group",
@@ -345,8 +381,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -366,8 +409,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">PingCAP new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">PingCAP new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -388,7 +438,7 @@
     ]
   },
   "time": {
-    "from": "now-3y",
+    "from": "now-1y",
     "to": "now-1M"
   },
   "timepicker": {

--- a/configs/dev/grafana/dashboards/pingcap/opened-to-merged.json
+++ b/configs/dev/grafana/dashboards/pingcap/opened-to-merged.json
@@ -31,7 +31,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 30,
-  "iteration": 1622080414825,
+  "iteration": 1622363662988,
   "links": [],
   "panels": [
     {
@@ -237,7 +237,7 @@
         },
         {
           "$$hashKey": "object:70",
-          "format": "short",
+          "format": "h",
           "label": "Opened to merged (15th percentile)",
           "logBase": 1,
           "max": null,
@@ -580,6 +580,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:76",
           "format": "h",
           "label": "Opened to merged (median & 85th percentile)",
           "logBase": 10,
@@ -588,12 +589,13 @@
           "show": true
         },
         {
+          "$$hashKey": "object:77",
           "format": "short",
           "label": "Opened to merged (15th percentile)",
           "logBase": 1,
           "max": null,
           "min": "0",
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
@@ -630,7 +632,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 39
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 13,
@@ -800,7 +802,7 @@
             },
             {
               "$$hashKey": "object:123",
-              "format": "short",
+              "format": "h",
               "label": "Opened to merged (15th percentile)",
               "logBase": 1,
               "max": null,
@@ -846,7 +848,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 40
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 14,
@@ -1016,7 +1018,7 @@
             },
             {
               "$$hashKey": "object:231",
-              "format": "short",
+              "format": "h",
               "label": "Opened to merged (15th percentile)",
               "logBase": 1,
               "max": null,
@@ -1270,5 +1272,5 @@
   "timezone": "",
   "title": "Opened to Merged",
   "uid": "16",
-  "version": 3
+  "version": 4
 }

--- a/configs/dev/grafana/dashboards/pingcap/prs-closed-in-repository-groups.json
+++ b/configs/dev/grafana/dashboards/pingcap/prs-closed-in-repository-groups.json
@@ -31,7 +31,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1007,
-  "iteration": 1622362680020,
+  "iteration": 1622365281282,
   "links": [],
   "panels": [
     {
@@ -671,7 +671,7 @@
   "style": "dark",
   "tags": [
     "dashboard",
-    "tikv",
+    "pingcap",
     "active"
   ],
   "templating": {
@@ -680,8 +680,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "TiKV",
-          "value": "TiKV"
+          "text": "PingCAP",
+          "value": "PingCAP"
         },
         "datasource": "psql",
         "definition": "",
@@ -787,8 +787,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"dashboard-header\">TiKV PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
-          "value": "<h1 id=\"dashboard-header\">TiKV PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
+          "text": "<h1 id=\"dashboard-header\">PingCAP PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">PingCAP PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -877,7 +877,7 @@
     ]
   },
   "timezone": "",
-  "title": "PRs Closed Repository Groups",
+  "title": "PRs Closed in Repository Groups",
   "uid": "pr-closed",
-  "version": 12
+  "version": 13
 }

--- a/configs/dev/grafana/dashboards/pingcap/prs-closed-repository-groups.json
+++ b/configs/dev/grafana/dashboards/pingcap/prs-closed-repository-groups.json
@@ -30,10 +30,340 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 40,
-  "iteration": 1622359049509,
+  "id": 1007,
+  "iteration": 1622362680020,
   "links": [],
   "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "psql",
+          "decimals": 0,
+          "description": "The number of new pull requests closed in [[repogroup]] repository group.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 14,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 13,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.0",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "hide": false,
+              "measurement": "reviewers_d",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsistop')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            },
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "hide": false,
+              "measurement": "reviewers_d",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsnottop')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PRs closed ([[repogroup_name]], [[period]], exclude bots)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [
+              "total"
+            ]
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:333",
+              "format": "none",
+              "label": "New PRs",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:334",
+              "format": "none",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "psql",
+          "decimals": 0,
+          "description": "PRs closed in all [[full_name]] repositories",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 5,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.0",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "PRs merged",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "measurement": "all_prs_merged_h",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsallcompany')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PRs closed in all [[full_name]] repositories ([[period]])",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:551",
+              "format": "short",
+              "label": "PRs merged",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:552",
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "PR closed (Not include merged PR)",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 21,
+      "panels": [],
+      "title": "PR closed or merged ",
+      "type": "row"
+    },
     {
       "aliasColors": {},
       "bars": true,
@@ -41,7 +371,7 @@
       "dashes": false,
       "datasource": "psql",
       "decimals": 0,
-      "description": "Number of new pull requests merged in [[repogroup]] repository group.",
+      "description": "The number of pull requests closed or merged in [[repogroup]] repository group.",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -51,13 +381,13 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 15,
+        "h": 14,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 2
       },
       "hiddenSeries": false,
-      "id": 13,
+      "id": 16,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -101,7 +431,7 @@
           "policy": "autogen",
           "query": "",
           "rawQuery": true,
-          "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_merged_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_merged_company[[repogroup_name]]excludebotsistop')\n  and period = '[[period]]'\norder by\n  time",
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"The top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsistop')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsistop')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -137,7 +467,7 @@
           "policy": "autogen",
           "query": "",
           "rawQuery": true,
-          "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_merged_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_merged_company[[repogroup_name]]excludebotsnottop')\n  and period = '[[period]]'\norder by\n  time",
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"Not top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsnottop')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsnottop')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
           "refId": "B",
           "resultFormat": "time_series",
           "select": [
@@ -165,7 +495,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "PRs Merged ([[repogroup_name]], [[period]], exclude bots)",
+      "title": "PRs closed or merged ([[repogroup_name]], [[period]], exclude bots)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -213,7 +543,7 @@
       "dashes": false,
       "datasource": "psql",
       "decimals": 0,
-      "description": "PRs merged in all [[full_name]] repositories",
+      "description": "PRs closed or merged in all [[full_name]] repositories",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -224,10 +554,10 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 16
       },
       "hiddenSeries": false,
-      "id": 3,
+      "id": 17,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -268,7 +598,7 @@
           "policy": "default",
           "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
           "rawQuery": true,
-          "rawSql": "select\n  time,\n  \"value\" as \"All PRs merged\"\nfrom\n  sall_prs_merged\nwhere\n  $__timeFilter(time)\n  and period = '[[period]]'\norder by\n  time",
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"The top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsallcompany')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsallcompany')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -296,7 +626,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "PRs merged in all [[full_name]] repositories ([[period]])",
+      "title": "PRs closed or merged  in all [[full_name]] repositories ([[period]])",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -312,6 +642,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:551",
           "format": "short",
           "label": "PRs merged",
           "logBase": 1,
@@ -320,6 +651,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:552",
           "format": "short",
           "label": "",
           "logBase": 1,
@@ -332,28 +664,6 @@
         "align": false,
         "alignLevel": null
       }
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 27
-      },
-      "id": 11,
-      "links": [],
-      "options": {
-        "content": "${docs:raw}",
-        "mode": "html"
-      },
-      "pluginVersion": "7.5.0",
-      "title": "Dashboard documentation",
-      "type": "text"
     }
   ],
   "refresh": false,
@@ -567,7 +877,7 @@
     ]
   },
   "timezone": "",
-  "title": "PRs Merged Repository Groups",
-  "uid": "24",
+  "title": "PRs Closed Repository Groups",
+  "uid": "pr-closed",
   "version": 12
 }

--- a/configs/dev/grafana/dashboards/pingcap/prs-merged-in-repository-groups.json
+++ b/configs/dev/grafana/dashboards/pingcap/prs-merged-in-repository-groups.json
@@ -31,7 +31,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 40,
-  "iteration": 1622359049509,
+  "iteration": 1622365252513,
   "links": [],
   "panels": [
     {
@@ -361,7 +361,7 @@
   "style": "dark",
   "tags": [
     "dashboard",
-    "tikv",
+    "pingcap",
     "active"
   ],
   "templating": {
@@ -370,8 +370,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "TiKV",
-          "value": "TiKV"
+          "text": "PingCAP",
+          "value": "PingCAP"
         },
         "datasource": "psql",
         "definition": "",
@@ -477,8 +477,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"dashboard-header\">TiKV PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
-          "value": "<h1 id=\"dashboard-header\">TiKV PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
+          "text": "<h1 id=\"dashboard-header\">PingCAP PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">PingCAP PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -567,7 +567,7 @@
     ]
   },
   "timezone": "",
-  "title": "PRs Merged Repository Groups",
+  "title": "PRs Merged in Repository Groups",
   "uid": "24",
-  "version": 12
+  "version": 13
 }

--- a/configs/dev/grafana/dashboards/pingcap/prs-opened-in-repository-groups.json
+++ b/configs/dev/grafana/dashboards/pingcap/prs-opened-in-repository-groups.json
@@ -30,8 +30,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 27,
-  "iteration": 1620638375143,
+  "id": 28,
+  "iteration": 1622359599936,
   "links": [],
   "panels": [
     {
@@ -51,10 +51,182 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 22,
+        "h": 14,
         "w": 24,
         "x": 0,
         "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_opened_company\nwhere\n  $__timeFilter(time)\n  and series = 'pr_opened_company[[repogroup]]excludebotsistop'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_opened_company\nwhere\n  $__timeFilter(time)\n  and series = 'pr_opened_company[[repogroup]]excludebotsnottop'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "New PRs created ([[repogroup_name]], [[period]], exclude bots)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:333",
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:334",
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "Number of new pull requests created in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 14
       },
       "hiddenSeries": false,
       "id": 1,
@@ -221,7 +393,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 29
       },
       "id": 11,
       "links": [],
@@ -239,16 +411,17 @@
   "style": "dark",
   "tags": [
     "dashboard",
-    "chaosmesh"
+    "pingcap",
+    "active"
   ],
   "templating": {
     "list": [
       {
         "allValue": null,
         "current": {
-          "tags": [],
-          "text": "Week",
-          "value": "w"
+          "selected": true,
+          "text": "7 Days MA",
+          "value": "d7"
         },
         "description": null,
         "error": null,
@@ -259,7 +432,7 @@
         "name": "period",
         "options": [
           {
-            "selected": false,
+            "selected": true,
             "text": "7 Days MA",
             "value": "d7"
           },
@@ -269,7 +442,7 @@
             "value": "d"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "Week",
             "value": "w"
           },
@@ -290,6 +463,7 @@
           }
         ],
         "query": "d,d7,w,m,q,y",
+        "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
       },
@@ -297,8 +471,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "Chaos Mesh",
-          "value": "Chaos Mesh"
+          "text": "PingCAP",
+          "value": "PingCAP"
         },
         "datasource": "psql",
         "definition": "",
@@ -381,8 +555,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"dashboard-header\">Chaos Mesh new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
-          "value": "<h1 id=\"dashboard-header\">Chaos Mesh new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
+          "text": "<h1 id=\"dashboard-header\">PingCAP new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">PingCAP new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -408,7 +582,7 @@
     ]
   },
   "time": {
-    "from": "now-1y",
+    "from": "now-90d",
     "to": "now"
   },
   "timepicker": {
@@ -437,7 +611,7 @@
     ]
   },
   "timezone": "",
-  "title": "New PRs in Repository Groups",
+  "title": "PRs Opened in Repository Groups",
   "uid": "15",
-  "version": 2
+  "version": 7
 }

--- a/configs/dev/grafana/dashboards/tikv/dashboards.json
+++ b/configs/dev/grafana/dashboards/tikv/dashboards.json
@@ -32,7 +32,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 15,
-  "iteration": 1622080154256,
+  "iteration": 1622359473216,
   "links": [
     {
       "icon": "dashboard",
@@ -234,7 +234,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
+        "h": 19,
         "w": 12,
         "x": 0,
         "y": 6
@@ -352,7 +352,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 17,
+        "h": 19,
         "w": 12,
         "x": 12,
         "y": 18
@@ -414,7 +414,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 25
       },
       "id": 8,
       "options": {
@@ -473,7 +473,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 37
       },
       "id": 18,
       "options": {
@@ -528,10 +528,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 37
       },
       "id": 14,
       "options": {
@@ -589,10 +589,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 45
       },
       "id": 16,
       "options": {
@@ -648,10 +648,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 12,
         "x": 12,
-        "y": 49
+        "y": 53
       },
       "id": 4,
       "links": [],
@@ -687,7 +687,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 57
       },
       "id": 6,
       "links": [],
@@ -714,8 +714,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"-full_name-home-dashboard\">TiKV Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://devstats-dev.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/tikv/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://tikv-devstats-dev.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for TiKV project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for TiKV project.</li>\n</ul>",
-          "value": "<h1 id=\"-full_name-home-dashboard\">TiKV Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://devstats-dev.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/tikv/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://tikv-devstats-dev.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for TiKV project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for TiKV project.</li>\n</ul>"
+          "text": "<h1 id=\"-full_name-home-dashboard\">TiKV Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://dev.devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/tikv/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://tikv.dev.devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for TiKV project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for TiKV project.</li>\n</ul>",
+          "value": "<h1 id=\"-full_name-home-dashboard\">TiKV Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://dev.devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/tikv/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://tikv.dev.devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for TiKV project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for TiKV project.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -770,8 +770,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "devstats-dev.tidb.io",
-          "value": "devstats-dev.tidb.io"
+          "text": "dev.devstats.tidb.io",
+          "value": "dev.devstats.tidb.io"
         },
         "datasource": "psql",
         "definition": "",
@@ -829,5 +829,5 @@
   "timezone": "",
   "title": "Dashboards",
   "uid": "8",
-  "version": 2
+  "version": 3
 }

--- a/configs/dev/grafana/dashboards/tikv/new-and-episodic-pr-contributors.json
+++ b/configs/dev/grafana/dashboards/tikv/new-and-episodic-pr-contributors.json
@@ -30,8 +30,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 20,
-  "iteration": 1533289967018,
+  "id": 26,
+  "iteration": 1622353566135,
   "links": [],
   "panels": [
     {
@@ -42,13 +42,19 @@
       "datasource": "psql",
       "decimals": 0,
       "description": "Displays the number of new/episodic issues and the number of new/episodic issues authors.\nThe episodic author is defined as someone who hasn't created issue in the last 3 months and no more than 12 issues overall.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 22,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 1,
       "legend": {
         "alignAsTable": false,
@@ -67,7 +73,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.0",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -192,6 +202,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "New/episodic issues ([[repogroup_name]], [[period]])",
       "tooltip": {
@@ -234,7 +245,11 @@
       }
     },
     {
-      "content": "${docs:raw}",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 13,
         "w": 24,
@@ -243,25 +258,37 @@
       },
       "id": 11,
       "links": [],
-      "mode": "html",
+      "options": {
+        "content": "${docs:raw}",
+        "mode": "html"
+      },
+      "pluginVersion": "7.5.0",
       "title": "Dashboard documentation",
       "type": "text"
     }
   ],
   "refresh": false,
-  "schemaVersion": 16,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "dashboard",
     "tikv",
-    "issues"
+    "issues",
+    "active"
   ],
   "templating": {
     "list": [
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "TiKV",
+          "value": "TiKV"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -286,6 +313,8 @@
           "text": "28 Days MA",
           "value": "d28"
         },
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Period",
@@ -324,8 +353,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Repository group",
@@ -345,8 +381,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -366,8 +409,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">TiKV new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">TiKV new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -388,7 +438,7 @@
     ]
   },
   "time": {
-    "from": "now-3y",
+    "from": "now-1y",
     "to": "now-1M"
   },
   "timepicker": {

--- a/configs/dev/grafana/dashboards/tikv/opened-to-merged.json
+++ b/configs/dev/grafana/dashboards/tikv/opened-to-merged.json
@@ -31,7 +31,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 30,
-  "iteration": 1622080414825,
+  "iteration": 1622363662988,
   "links": [],
   "panels": [
     {
@@ -237,7 +237,7 @@
         },
         {
           "$$hashKey": "object:70",
-          "format": "short",
+          "format": "h",
           "label": "Opened to merged (15th percentile)",
           "logBase": 1,
           "max": null,
@@ -580,6 +580,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:76",
           "format": "h",
           "label": "Opened to merged (median & 85th percentile)",
           "logBase": 10,
@@ -588,12 +589,13 @@
           "show": true
         },
         {
+          "$$hashKey": "object:77",
           "format": "short",
           "label": "Opened to merged (15th percentile)",
           "logBase": 1,
           "max": null,
           "min": "0",
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
@@ -630,7 +632,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 39
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 13,
@@ -800,7 +802,7 @@
             },
             {
               "$$hashKey": "object:123",
-              "format": "short",
+              "format": "h",
               "label": "Opened to merged (15th percentile)",
               "logBase": 1,
               "max": null,
@@ -846,7 +848,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 40
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 14,
@@ -1016,7 +1018,7 @@
             },
             {
               "$$hashKey": "object:231",
-              "format": "short",
+              "format": "h",
               "label": "Opened to merged (15th percentile)",
               "logBase": 1,
               "max": null,
@@ -1270,5 +1272,5 @@
   "timezone": "",
   "title": "Opened to Merged",
   "uid": "16",
-  "version": 3
+  "version": 4
 }

--- a/configs/dev/grafana/dashboards/tikv/prs-closed-in-repository-groups.json
+++ b/configs/dev/grafana/dashboards/tikv/prs-closed-in-repository-groups.json
@@ -31,7 +31,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 1007,
-  "iteration": 1622362680020,
+  "iteration": 1622365281282,
   "links": [],
   "panels": [
     {
@@ -671,7 +671,7 @@
   "style": "dark",
   "tags": [
     "dashboard",
-    "chaosmesh",
+    "tikv",
     "active"
   ],
   "templating": {
@@ -680,8 +680,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "ChaosMesh",
-          "value": "ChaosMesh"
+          "text": "TiKV",
+          "value": "TiKV"
         },
         "datasource": "psql",
         "definition": "",
@@ -787,8 +787,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"dashboard-header\">ChaosMesh PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
-          "value": "<h1 id=\"dashboard-header\">ChaosMesh PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
+          "text": "<h1 id=\"dashboard-header\">TiKV PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">TiKV PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -877,7 +877,7 @@
     ]
   },
   "timezone": "",
-  "title": "PRs Closed Repository Groups",
+  "title": "PRs Closed in Repository Groups",
   "uid": "pr-closed",
-  "version": 12
+  "version": 13
 }

--- a/configs/dev/grafana/dashboards/tikv/prs-closed-repository-groups.json
+++ b/configs/dev/grafana/dashboards/tikv/prs-closed-repository-groups.json
@@ -30,10 +30,340 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 40,
-  "iteration": 1622359049509,
+  "id": 1007,
+  "iteration": 1622362680020,
   "links": [],
   "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "psql",
+          "decimals": 0,
+          "description": "The number of new pull requests closed in [[repogroup]] repository group.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 14,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 13,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.0",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "hide": false,
+              "measurement": "reviewers_d",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsistop')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            },
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "hide": false,
+              "measurement": "reviewers_d",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsnottop')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PRs closed ([[repogroup_name]], [[period]], exclude bots)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [
+              "total"
+            ]
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:333",
+              "format": "none",
+              "label": "New PRs",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:334",
+              "format": "none",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "psql",
+          "decimals": 0,
+          "description": "PRs closed in all [[full_name]] repositories",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 5,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.0",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "PRs merged",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "measurement": "all_prs_merged_h",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsallcompany')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PRs closed in all [[full_name]] repositories ([[period]])",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:551",
+              "format": "short",
+              "label": "PRs merged",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:552",
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "PR closed (Not include merged PR)",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 21,
+      "panels": [],
+      "title": "PR closed or merged ",
+      "type": "row"
+    },
     {
       "aliasColors": {},
       "bars": true,
@@ -41,7 +371,7 @@
       "dashes": false,
       "datasource": "psql",
       "decimals": 0,
-      "description": "Number of new pull requests merged in [[repogroup]] repository group.",
+      "description": "The number of pull requests closed or merged in [[repogroup]] repository group.",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -51,13 +381,13 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 15,
+        "h": 14,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 2
       },
       "hiddenSeries": false,
-      "id": 13,
+      "id": 16,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -101,7 +431,7 @@
           "policy": "autogen",
           "query": "",
           "rawQuery": true,
-          "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_merged_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_merged_company[[repogroup_name]]excludebotsistop')\n  and period = '[[period]]'\norder by\n  time",
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"The top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsistop')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsistop')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -137,7 +467,7 @@
           "policy": "autogen",
           "query": "",
           "rawQuery": true,
-          "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_merged_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_merged_company[[repogroup_name]]excludebotsnottop')\n  and period = '[[period]]'\norder by\n  time",
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"Not top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsnottop')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsnottop')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
           "refId": "B",
           "resultFormat": "time_series",
           "select": [
@@ -165,7 +495,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "PRs Merged ([[repogroup_name]], [[period]], exclude bots)",
+      "title": "PRs closed or merged ([[repogroup_name]], [[period]], exclude bots)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -213,7 +543,7 @@
       "dashes": false,
       "datasource": "psql",
       "decimals": 0,
-      "description": "PRs merged in all [[full_name]] repositories",
+      "description": "PRs closed or merged in all [[full_name]] repositories",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -224,10 +554,10 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 16
       },
       "hiddenSeries": false,
-      "id": 3,
+      "id": 17,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -268,7 +598,7 @@
           "policy": "default",
           "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
           "rawQuery": true,
-          "rawSql": "select\n  time,\n  \"value\" as \"All PRs merged\"\nfrom\n  sall_prs_merged\nwhere\n  $__timeFilter(time)\n  and period = '[[period]]'\norder by\n  time",
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"The top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsallcompany')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsallcompany')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
           "refId": "A",
           "resultFormat": "time_series",
           "select": [
@@ -296,7 +626,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "PRs merged in all [[full_name]] repositories ([[period]])",
+      "title": "PRs closed or merged  in all [[full_name]] repositories ([[period]])",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -312,6 +642,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:551",
           "format": "short",
           "label": "PRs merged",
           "logBase": 1,
@@ -320,6 +651,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:552",
           "format": "short",
           "label": "",
           "logBase": 1,
@@ -332,28 +664,6 @@
         "align": false,
         "alignLevel": null
       }
-    },
-    {
-      "datasource": null,
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 27
-      },
-      "id": 11,
-      "links": [],
-      "options": {
-        "content": "${docs:raw}",
-        "mode": "html"
-      },
-      "pluginVersion": "7.5.0",
-      "title": "Dashboard documentation",
-      "type": "text"
     }
   ],
   "refresh": false,
@@ -567,7 +877,7 @@
     ]
   },
   "timezone": "",
-  "title": "PRs Merged Repository Groups",
-  "uid": "24",
+  "title": "PRs Closed Repository Groups",
+  "uid": "pr-closed",
   "version": 12
 }

--- a/configs/dev/grafana/dashboards/tikv/prs-merged-in-repository-groups.json
+++ b/configs/dev/grafana/dashboards/tikv/prs-merged-in-repository-groups.json
@@ -31,7 +31,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 40,
-  "iteration": 1622359049509,
+  "iteration": 1622365252513,
   "links": [],
   "panels": [
     {
@@ -361,7 +361,7 @@
   "style": "dark",
   "tags": [
     "dashboard",
-    "chaosmesh",
+    "tikv",
     "active"
   ],
   "templating": {
@@ -370,8 +370,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "ChaosMesh",
-          "value": "ChaosMesh"
+          "text": "TiKV",
+          "value": "TiKV"
         },
         "datasource": "psql",
         "definition": "",
@@ -477,8 +477,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"dashboard-header\">ChaosMesh PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
-          "value": "<h1 id=\"dashboard-header\">ChaosMesh PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
+          "text": "<h1 id=\"dashboard-header\">TiKV PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">TiKV PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -567,7 +567,7 @@
     ]
   },
   "timezone": "",
-  "title": "PRs Merged Repository Groups",
+  "title": "PRs Merged in Repository Groups",
   "uid": "24",
-  "version": 12
+  "version": 13
 }

--- a/configs/dev/grafana/dashboards/tikv/prs-opened-in-repository-groups.json
+++ b/configs/dev/grafana/dashboards/tikv/prs-opened-in-repository-groups.json
@@ -30,8 +30,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 27,
-  "iteration": 1620637560827,
+  "id": 28,
+  "iteration": 1622359599936,
   "links": [],
   "panels": [
     {
@@ -51,10 +51,182 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 22,
+        "h": 14,
         "w": 24,
         "x": 0,
         "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_opened_company\nwhere\n  $__timeFilter(time)\n  and series = 'pr_opened_company[[repogroup]]excludebotsistop'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_opened_company\nwhere\n  $__timeFilter(time)\n  and series = 'pr_opened_company[[repogroup]]excludebotsnottop'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "New PRs created ([[repogroup_name]], [[period]], exclude bots)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:333",
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:334",
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "Number of new pull requests created in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 14
       },
       "hiddenSeries": false,
       "id": 1,
@@ -221,7 +393,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 29
       },
       "id": 11,
       "links": [],
@@ -239,16 +411,17 @@
   "style": "dark",
   "tags": [
     "dashboard",
-    "tikv"
+    "tikv",
+    "active"
   ],
   "templating": {
     "list": [
       {
         "allValue": null,
         "current": {
-          "tags": [],
-          "text": "Week",
-          "value": "w"
+          "selected": true,
+          "text": "7 Days MA",
+          "value": "d7"
         },
         "description": null,
         "error": null,
@@ -259,7 +432,7 @@
         "name": "period",
         "options": [
           {
-            "selected": false,
+            "selected": true,
             "text": "7 Days MA",
             "value": "d7"
           },
@@ -269,7 +442,7 @@
             "value": "d"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "Week",
             "value": "w"
           },
@@ -290,6 +463,7 @@
           }
         ],
         "query": "d,d7,w,m,q,y",
+        "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
       },
@@ -408,7 +582,7 @@
     ]
   },
   "time": {
-    "from": "now-1y",
+    "from": "now-90d",
     "to": "now"
   },
   "timepicker": {
@@ -437,7 +611,7 @@
     ]
   },
   "timezone": "",
-  "title": "New PRs in Repository Groups",
+  "title": "PRs Opened in Repository Groups",
   "uid": "15",
-  "version": 2
+  "version": 7
 }

--- a/configs/dev/grafana/pingcap/custom_sqlite.sql
+++ b/configs/dev/grafana/pingcap/custom_sqlite.sql
@@ -109,7 +109,9 @@ set
   )
 where
   slug in (
-    'new-prs-in-repository-groups',
+    'prs-opened-in-repository-groups',
+    'prs-merged-in-repository-groups',
+    'prs-closed-in-repository-groups',
     'open-pr-age-by-repository-group',
     'opened-to-merged',
     'pr-reviews-by-contributor',
@@ -117,7 +119,6 @@ where
     'prs-approval-repository-groups',
     'prs-authors-repository-groups',
     'prs-authors-table',
-    'prs-merged-repository-groups',
     'prs-mergers-table',
     'time-to-merge-in-repository-groups'
   )

--- a/configs/dev/grafana/tikv/custom_sqlite.sql
+++ b/configs/dev/grafana/tikv/custom_sqlite.sql
@@ -109,7 +109,9 @@ set
   )
 where
   slug in (
-    'new-prs-in-repository-groups',
+    'prs-opened-in-repository-groups',
+    'prs-merged-in-repository-groups',
+    'prs-closed-in-repository-groups',
     'open-pr-age-by-repository-group',
     'opened-to-merged',
     'pr-reviews-by-contributor',
@@ -117,7 +119,6 @@ where
     'prs-approval-repository-groups',
     'prs-authors-repository-groups',
     'prs-authors-table',
-    'prs-merged-repository-groups',
     'prs-mergers-table',
     'time-to-merge-in-repository-groups'
   )

--- a/configs/dev/metrics/shared/episodic_contributors.sql
+++ b/configs/dev/metrics/shared/episodic_contributors.sql
@@ -1,0 +1,71 @@
+with prev as (
+  select 
+    distinct user_id
+  from
+    gha_pull_requests
+  where
+    created_at >= date '{{from}}' - '3 months'::interval
+    and created_at < '{{from}}'
+), prev_cnt as (
+  select 
+    user_id, 
+    count(distinct id) as cnt
+  from
+    gha_pull_requests
+  where
+    created_at < '{{from}}'
+  group by
+    user_id
+)
+-- All repositories.
+select
+  'epis_contrib;All;contrib,prs' as name,
+  round(count(distinct pr.user_id) / {{n}}, 2) as contributors,
+  round(count(distinct pr.id) / {{n}}, 2) as prs
+from
+  gha_pull_requests pr
+left join
+  prev_cnt pc
+on
+  pc.user_id = pr.user_id
+where
+  pr.created_at >= '{{from}}'
+  and pr.created_at < '{{to}}'
+  and (lower(dup_user_login) {{exclude_bots}})
+  and pr.user_id not in (select user_id from prev)
+  and (pc.user_id is null or pc.cnt <= 12)
+union
+-- Repository group.
+select 
+  sub.name,
+  round(count(distinct sub.user_id) / {{n}}, 2) as contributors,
+  round(count(distinct sub.id) / {{n}}, 2) as prs
+from (
+  select 
+    'epis_contrib;' || r.repo_group || ';contrib,prs' as name,
+    pr.user_id,
+    pr.id
+  from
+    gha_repos r,
+    gha_pull_requests pr
+  left join
+    prev_cnt pc
+  on
+    pc.user_id = pr.user_id
+  where
+    pr.dup_repo_id = r.id
+    and pr.dup_repo_name = r.name
+    and pr.created_at >= '{{from}}'
+    and pr.created_at < '{{to}}'
+    and (lower(dup_user_login) {{exclude_bots}})
+    and pr.user_id not in (select user_id from prev)
+    and (pc.user_id is null or pc.cnt <= 12)
+  ) sub
+where
+  sub.name is not null
+group by
+  sub.name
+order by
+  prs desc,
+  name asc
+;

--- a/configs/dev/metrics/shared/metrics.yaml
+++ b/configs/dev/metrics/shared/metrics.yaml
@@ -224,6 +224,14 @@ metrics:
     skip: w7,m7,q7,y7
     merge_series: new_prs
     drop: snew_prs
+  - name: PRs opened group by company
+    series_name_or_func: multi_row_single_column
+    sql: pr_opened_company
+    periods: d,w,m,q,y
+    aggregate: 1,7
+    skip: w7,m7,q7,y7
+    merge_series: pr_opened_company
+    drop: spr_opened_company
   - name: PRs authors
     series_name_or_func: multi_row_single_column
     sql: prs_authors
@@ -240,6 +248,22 @@ metrics:
     skip: w7,m7,q7,y7
     multi_value: true
     drop: sgrp_pr_merg
+  - name: PRs merged group by company
+    series_name_or_func: multi_row_single_column
+    sql: pr_merged_company
+    periods: d,w,m,q,y
+    aggregate: 1,7
+    skip: w7,m7,q7,y7
+    merge_series: pr_merged_company
+    drop: spr_merged_company
+  - name: PRs closed group by company
+    series_name_or_func: multi_row_single_column
+    sql: pr_closed_company
+    periods: d,w,m,q,y
+    aggregate: 1,7
+    skip: w7,m7,q7,y7
+    merge_series: pr_closed_company
+    drop: spr_closed_company
   - name: PRs approval
     series_name_or_func: multi_row_multi_column
     sql: prs_state

--- a/configs/dev/metrics/shared/new_contributors.sql
+++ b/configs/dev/metrics/shared/new_contributors.sql
@@ -1,0 +1,49 @@
+with prev as (
+  select distinct user_id
+  from
+    gha_pull_requests
+  where
+    created_at < '{{from}}'
+    and (lower(dup_user_login) {{exclude_bots}})
+)
+-- All repositroies.
+select
+  'new_contrib;All;contrib,prs' as name,
+  round(count(distinct user_id) / {{n}}, 2) as contributors,
+  round(count(distinct id) / {{n}}, 2) as prs
+from
+  gha_pull_requests
+where
+  created_at >= '{{from}}'
+  and created_at < '{{to}}'
+  and user_id not in (select user_id from prev)
+union
+-- Repository group.
+select 
+  sub.name,
+  round(count(distinct sub.user_id) / {{n}}, 2) as contributors,
+  round(count(distinct sub.id) / {{n}}, 2) as prs
+from (
+  select 
+    'new_contrib;' || r.repo_group || ';contrib,prs' as name,
+    pr.user_id,
+    pr.id
+  from
+    gha_repos r,
+    gha_pull_requests pr
+  where
+    pr.dup_repo_id = r.id
+    and pr.dup_repo_name = r.name
+    and pr.created_at >= '{{from}}'
+    and pr.created_at < '{{to}}'
+    and (lower(dup_user_login) {{exclude_bots}})
+    and pr.user_id not in (select user_id from prev)
+  ) sub
+where
+  sub.name is not null
+group by
+  sub.name
+order by
+  prs desc,
+  name asc
+;

--- a/configs/dev/metrics/shared/pr_closed_company.sql
+++ b/configs/dev/metrics/shared/pr_closed_company.sql
@@ -1,0 +1,184 @@
+with closed_prs as (
+    select
+        pr.id id,
+        lower(pr.dup_user_login) author_login,
+        r.repo_group repo_group,
+        case when aa.company_name = 'PingCAP' then 'is-top-contributing-company'
+             else 'not-top-contributing-company'
+        end company_category
+    from
+        gha_pull_requests pr
+    left join
+        gha_repos r
+    on
+        r.id = pr.dup_repo_id
+        and r.name = pr.dup_repo_name
+        and r.repo_group is not null
+    left join
+        gha_actors_affiliations aa
+    on
+        aa.actor_id = pr.user_id
+        and aa.dt_from <= pr.created_at
+        and aa.dt_to > pr.created_at
+    where
+        merged_at is null
+        and closed_at is not null
+        and closed_at >= '{{from}}'
+        and closed_at < '{{to}}'
+)
+-- all repos, include bots
+
+-- all repositories, include bots, all companies.
+(
+    select
+        'pr_closed_company,all_repo_include_bot_all_company' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        closed_prs
+)
+-- all repositories, include bots, is top contributing company.
+union
+(
+    select
+        'pr_closed_company,all_repo_include_bot_is_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        closed_prs
+    where
+        company_category = 'is-top-contributing-company'
+)
+
+-- all repositories, include bots, not top contributing company.
+union
+(
+    select
+        'pr_closed_company,all_repo_include_bot_not_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        closed_prs
+    where
+        company_category = 'not-top-contributing-company'
+)
+
+-- all repos, exclude bots
+
+-- all repositories, exclude bots, all companies.
+union
+(
+    select
+        'pr_closed_company,all_repo_exclude_bots_all_company' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        closed_prs
+    where
+        author_login {{exclude_bots}}
+)
+-- all repositories, exclude bots, is top contributing company.
+union
+(
+    select
+        'pr_closed_company,all_repo_exclude_bots_is_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        closed_prs
+    where
+        company_category = 'is-top-contributing-company'
+        and author_login {{exclude_bots}}
+)
+-- all repositories, exclude bots, not top contributing company.
+union
+(
+    select
+        'pr_closed_company,all_repo_exclude_bots_not_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        closed_prs
+    where
+        company_category = 'not-top-contributing-company'
+        and author_login {{exclude_bots}}
+)
+
+-- repo group, include bots
+
+-- repository group, include bots, all companies.
+union
+(
+    select
+        'pr_closed_company,' || repo_group  || '_include_bot_all_company' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        closed_prs
+    group by
+        repo_group
+)
+-- repository group, include bots, is top contributing company.
+union
+(
+    select
+        'pr_closed_company,' || repo_group  || '_include_bot_is_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        closed_prs
+    where
+        company_category = 'is-top-contributing-company'
+    group by
+        repo_group
+)
+
+-- repository group, include bots, not top contributing company.
+union
+(
+    select
+        'pr_closed_company,' || repo_group  || '_include_bot_not_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        closed_prs
+    where
+        company_category = 'not-top-contributing-company'
+    group by
+        repo_group
+)
+
+-- repo group, exclude bots
+
+-- repository group, exclude bots, all companies.
+union
+(
+    select
+        'pr_closed_company,' || repo_group  || '_exclude_bot_all_company' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        closed_prs
+    where
+        author_login {{exclude_bots}}
+    group by
+        repo_group
+)
+-- repository group, exclude bots, is top contributing company.
+union
+(
+    select
+        'pr_closed_company,' || repo_group  || '_exclude_bot_is_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        closed_prs
+    where
+        company_category = 'is-top-contributing-company'
+        and author_login {{exclude_bots}}
+    group by
+        repo_group
+)
+-- repository group, exclude bots, not top contributing company.
+union
+(
+    select
+        'pr_closed_company,' || repo_group  || '_exclude_bot_not_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        closed_prs
+    where
+        company_category = 'not-top-contributing-company'
+        and author_login {{exclude_bots}}
+    group by
+        repo_group
+)

--- a/configs/dev/metrics/shared/pr_closed_company.sql
+++ b/configs/dev/metrics/shared/pr_closed_company.sql
@@ -31,7 +31,7 @@ with closed_prs as (
 -- all repositories, include bots, all companies.
 (
     select
-        'pr_closed_company,all_repo_include_bot_all_company' as series,
+        'pr_closed_company,all_include_bot_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
@@ -40,7 +40,7 @@ with closed_prs as (
 union
 (
     select
-        'pr_closed_company,all_repo_include_bot_is_top' as series,
+        'pr_closed_company,all_include_bot_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
@@ -52,7 +52,7 @@ union
 union
 (
     select
-        'pr_closed_company,all_repo_include_bot_not_top' as series,
+        'pr_closed_company,all_include_bot_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
@@ -66,7 +66,7 @@ union
 union
 (
     select
-        'pr_closed_company,all_repo_exclude_bots_all_company' as series,
+        'pr_closed_company,all_exclude_bots_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
@@ -77,7 +77,7 @@ union
 union
 (
     select
-        'pr_closed_company,all_repo_exclude_bots_is_top' as series,
+        'pr_closed_company,all_exclude_bots_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
@@ -89,7 +89,7 @@ union
 union
 (
     select
-        'pr_closed_company,all_repo_exclude_bots_not_top' as series,
+        'pr_closed_company,all_exclude_bots_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs

--- a/configs/dev/metrics/shared/pr_closed_company.sql
+++ b/configs/dev/metrics/shared/pr_closed_company.sql
@@ -31,7 +31,7 @@ with closed_prs as (
 -- all repositories, include bots, all companies.
 (
     select
-        'pr_closed_company,all_include_bot_all_company' as series,
+        'pr_closed_company,all_include_bots_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
@@ -40,7 +40,7 @@ with closed_prs as (
 union
 (
     select
-        'pr_closed_company,all_include_bot_is_top' as series,
+        'pr_closed_company,all_include_bots_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
@@ -52,7 +52,7 @@ union
 union
 (
     select
-        'pr_closed_company,all_include_bot_not_top' as series,
+        'pr_closed_company,all_include_bots_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
@@ -71,7 +71,7 @@ union
     from
         closed_prs
     where
-        author_login {{exclude_bots}}
+        lower(author_login) {{exclude_bots}}
 )
 -- all repositories, exclude bots, is top contributing company.
 union
@@ -83,7 +83,7 @@ union
         closed_prs
     where
         company_category = 'is-top-contributing-company'
-        and author_login {{exclude_bots}}
+        and (lower(author_login) {{exclude_bots}})
 )
 -- all repositories, exclude bots, not top contributing company.
 union
@@ -95,7 +95,7 @@ union
         closed_prs
     where
         company_category = 'not-top-contributing-company'
-        and author_login {{exclude_bots}}
+        and (lower(author_login) {{exclude_bots}})
 )
 
 -- repo group, include bots
@@ -104,7 +104,7 @@ union
 union
 (
     select
-        'pr_closed_company,' || repo_group  || '_include_bot_all_company' as series,
+        'pr_closed_company,' || repo_group  || '_include_bots_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
@@ -115,7 +115,7 @@ union
 union
 (
     select
-        'pr_closed_company,' || repo_group  || '_include_bot_is_top' as series,
+        'pr_closed_company,' || repo_group  || '_include_bots_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
@@ -129,7 +129,7 @@ union
 union
 (
     select
-        'pr_closed_company,' || repo_group  || '_include_bot_not_top' as series,
+        'pr_closed_company,' || repo_group  || '_include_bots_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
@@ -145,12 +145,12 @@ union
 union
 (
     select
-        'pr_closed_company,' || repo_group  || '_exclude_bot_all_company' as series,
+        'pr_closed_company,' || repo_group  || '_exclude_bots_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
     where
-        author_login {{exclude_bots}}
+        lower(author_login) {{exclude_bots}}
     group by
         repo_group
 )
@@ -158,13 +158,13 @@ union
 union
 (
     select
-        'pr_closed_company,' || repo_group  || '_exclude_bot_is_top' as series,
+        'pr_closed_company,' || repo_group  || '_exclude_bots_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
     where
         company_category = 'is-top-contributing-company'
-        and author_login {{exclude_bots}}
+        and (lower(author_login) {{exclude_bots}})
     group by
         repo_group
 )
@@ -172,13 +172,13 @@ union
 union
 (
     select
-        'pr_closed_company,' || repo_group  || '_exclude_bot_not_top' as series,
+        'pr_closed_company,' || repo_group  || '_exclude_bots_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         closed_prs
     where
         company_category = 'not-top-contributing-company'
-        and author_login {{exclude_bots}}
+        and (lower(author_login) {{exclude_bots}})
     group by
         repo_group
 )

--- a/configs/dev/metrics/shared/pr_merged_company.sql
+++ b/configs/dev/metrics/shared/pr_merged_company.sql
@@ -1,0 +1,183 @@
+with merged_prs as (
+    select
+        pr.id id,
+        lower(pr.dup_user_login) author_login,
+        r.repo_group repo_group,
+        case when aa.company_name = 'PingCAP' then 'is-top-contributing-company'
+             else 'not-top-contributing-company'
+        end company_category
+    from
+        gha_pull_requests pr
+    left join
+        gha_repos r
+    on
+        r.id = pr.dup_repo_id
+        and r.name = pr.dup_repo_name
+        and r.repo_group is not null
+    left join
+        gha_actors_affiliations aa
+    on
+        aa.actor_id = pr.user_id
+        and aa.dt_from <= pr.created_at
+        and aa.dt_to > pr.created_at
+    where
+        merged_at is not null
+        and merged_at >= '{{from}}'
+        and merged_at < '{{to}}'
+)
+-- all repos, include bots
+
+-- all repositories, include bots, all companies.
+(
+    select
+        'pr_merged_company,all_repo_include_bot_all_company' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        merged_prs
+)
+-- all repositories, include bots, is top contributing company.
+union
+(
+    select
+        'pr_merged_company,all_repo_include_bot_is_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        merged_prs
+    where
+        company_category = 'is-top-contributing-company'
+)
+
+-- all repositories, include bots, not top contributing company.
+union
+(
+    select
+        'pr_merged_company,all_repo_include_bot_not_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        merged_prs
+    where
+        company_category = 'not-top-contributing-company'
+)
+
+-- all repos, exclude bots
+
+-- all repositories, exclude bots, all companies.
+union
+(
+    select
+        'pr_merged_company,all_repo_exclude_bots_all_company' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        merged_prs
+    where
+        author_login {{exclude_bots}}
+)
+-- all repositories, exclude bots, is top contributing company.
+union
+(
+    select
+        'pr_merged_company,all_repo_exclude_bots_is_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        merged_prs
+    where
+        company_category = 'is-top-contributing-company'
+        and author_login {{exclude_bots}}
+)
+-- all repositories, exclude bots, not top contributing company.
+union
+(
+    select
+        'pr_merged_company,all_repo_exclude_bots_not_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        merged_prs
+    where
+        company_category = 'not-top-contributing-company'
+        and author_login {{exclude_bots}}
+)
+
+-- repo group, include bots
+
+-- repository group, include bots, all companies.
+union
+(
+    select
+        'pr_merged_company,' || repo_group  || '_include_bot_all_company' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        merged_prs
+    group by
+        repo_group
+)
+-- repository group, include bots, is top contributing company.
+union
+(
+    select
+        'pr_merged_company,' || repo_group  || '_include_bot_is_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        merged_prs
+    where
+        company_category = 'is-top-contributing-company'
+    group by
+        repo_group
+)
+
+-- repository group, include bots, not top contributing company.
+union
+(
+    select
+        'pr_merged_company,' || repo_group  || '_include_bot_not_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        merged_prs
+    where
+        company_category = 'not-top-contributing-company'
+    group by
+        repo_group
+)
+
+-- repo group, exclude bots
+
+-- repository group, exclude bots, all companies.
+union
+(
+    select
+        'pr_merged_company,' || repo_group  || '_exclude_bot_all_company' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        merged_prs
+    where
+        author_login {{exclude_bots}}
+    group by
+        repo_group
+)
+-- repository group, exclude bots, is top contributing company.
+union
+(
+    select
+        'pr_merged_company,' || repo_group  || '_exclude_bot_is_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        merged_prs
+    where
+        company_category = 'is-top-contributing-company'
+        and author_login {{exclude_bots}}
+    group by
+        repo_group
+)
+-- repository group, exclude bots, not top contributing company.
+union
+(
+    select
+        'pr_merged_company,' || repo_group  || '_exclude_bot_not_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        merged_prs
+    where
+        company_category = 'not-top-contributing-company'
+        and author_login {{exclude_bots}}
+    group by
+        repo_group
+)

--- a/configs/dev/metrics/shared/pr_merged_company.sql
+++ b/configs/dev/metrics/shared/pr_merged_company.sql
@@ -30,7 +30,7 @@ with merged_prs as (
 -- all repositories, include bots, all companies.
 (
     select
-        'pr_merged_company,all_repo_include_bot_all_company' as series,
+        'pr_merged_company,all_include_bot_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
@@ -39,7 +39,7 @@ with merged_prs as (
 union
 (
     select
-        'pr_merged_company,all_repo_include_bot_is_top' as series,
+        'pr_merged_company,all_include_bot_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
@@ -51,7 +51,7 @@ union
 union
 (
     select
-        'pr_merged_company,all_repo_include_bot_not_top' as series,
+        'pr_merged_company,all_include_bot_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
@@ -65,7 +65,7 @@ union
 union
 (
     select
-        'pr_merged_company,all_repo_exclude_bots_all_company' as series,
+        'pr_merged_company,all_exclude_bots_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
@@ -76,7 +76,7 @@ union
 union
 (
     select
-        'pr_merged_company,all_repo_exclude_bots_is_top' as series,
+        'pr_merged_company,all_exclude_bots_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
@@ -88,7 +88,7 @@ union
 union
 (
     select
-        'pr_merged_company,all_repo_exclude_bots_not_top' as series,
+        'pr_merged_company,all_exclude_bots_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs

--- a/configs/dev/metrics/shared/pr_merged_company.sql
+++ b/configs/dev/metrics/shared/pr_merged_company.sql
@@ -30,7 +30,7 @@ with merged_prs as (
 -- all repositories, include bots, all companies.
 (
     select
-        'pr_merged_company,all_include_bot_all_company' as series,
+        'pr_merged_company,all_include_bots_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
@@ -39,7 +39,7 @@ with merged_prs as (
 union
 (
     select
-        'pr_merged_company,all_include_bot_is_top' as series,
+        'pr_merged_company,all_include_bots_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
@@ -51,7 +51,7 @@ union
 union
 (
     select
-        'pr_merged_company,all_include_bot_not_top' as series,
+        'pr_merged_company,all_include_bots_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
@@ -70,7 +70,7 @@ union
     from
         merged_prs
     where
-        author_login {{exclude_bots}}
+        lower(author_login) {{exclude_bots}}
 )
 -- all repositories, exclude bots, is top contributing company.
 union
@@ -82,7 +82,7 @@ union
         merged_prs
     where
         company_category = 'is-top-contributing-company'
-        and author_login {{exclude_bots}}
+        and (lower(author_login) {{exclude_bots}})
 )
 -- all repositories, exclude bots, not top contributing company.
 union
@@ -94,7 +94,7 @@ union
         merged_prs
     where
         company_category = 'not-top-contributing-company'
-        and author_login {{exclude_bots}}
+        and (lower(author_login) {{exclude_bots}})
 )
 
 -- repo group, include bots
@@ -103,7 +103,7 @@ union
 union
 (
     select
-        'pr_merged_company,' || repo_group  || '_include_bot_all_company' as series,
+        'pr_merged_company,' || repo_group  || '_include_bots_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
@@ -114,7 +114,7 @@ union
 union
 (
     select
-        'pr_merged_company,' || repo_group  || '_include_bot_is_top' as series,
+        'pr_merged_company,' || repo_group  || '_include_bots_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
@@ -128,7 +128,7 @@ union
 union
 (
     select
-        'pr_merged_company,' || repo_group  || '_include_bot_not_top' as series,
+        'pr_merged_company,' || repo_group  || '_include_bots_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
@@ -144,12 +144,12 @@ union
 union
 (
     select
-        'pr_merged_company,' || repo_group  || '_exclude_bot_all_company' as series,
+        'pr_merged_company,' || repo_group  || '_exclude_bots_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
     where
-        author_login {{exclude_bots}}
+        lower(author_login) {{exclude_bots}}
     group by
         repo_group
 )
@@ -157,13 +157,13 @@ union
 union
 (
     select
-        'pr_merged_company,' || repo_group  || '_exclude_bot_is_top' as series,
+        'pr_merged_company,' || repo_group  || '_exclude_bots_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
     where
         company_category = 'is-top-contributing-company'
-        and author_login {{exclude_bots}}
+        and (lower(author_login) {{exclude_bots}})
     group by
         repo_group
 )
@@ -171,13 +171,13 @@ union
 union
 (
     select
-        'pr_merged_company,' || repo_group  || '_exclude_bot_not_top' as series,
+        'pr_merged_company,' || repo_group  || '_exclude_bots_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         merged_prs
     where
         company_category = 'not-top-contributing-company'
-        and author_login {{exclude_bots}}
+        and (lower(author_login) {{exclude_bots}})
     group by
         repo_group
 )

--- a/configs/dev/metrics/shared/pr_opened_company.sql
+++ b/configs/dev/metrics/shared/pr_opened_company.sql
@@ -32,7 +32,7 @@ with opened_prs as (
 -- all repositories, include bots, all companies.
 (
     select
-        'pr_opened_company,all_include_bot_all_company' as series,
+        'pr_opened_company,all_include_bots_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
@@ -41,7 +41,7 @@ with opened_prs as (
 union
 (
     select
-        'pr_opened_company,all_include_bot_is_top' as series,
+        'pr_opened_company,all_include_bots_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
@@ -53,7 +53,7 @@ union
 union
 (
     select
-        'pr_opened_company,all_include_bot_not_top' as series,
+        'pr_opened_company,all_include_bots_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
@@ -72,7 +72,7 @@ union
     from
         opened_prs
     where
-        author_login {{exclude_bots}}
+        lower(author_login) {{exclude_bots}}
 )
 -- all repositories, exclude bots, is top contributing company.
 union
@@ -84,7 +84,7 @@ union
         opened_prs
     where
         company_category = 'is-top-contributing-company'
-        and author_login {{exclude_bots}}
+        and (lower(author_login) {{exclude_bots}})
 )
 -- all repositories, exclude bots, not top contributing company.
 union
@@ -96,7 +96,7 @@ union
         opened_prs
     where
         company_category = 'not-top-contributing-company'
-        and author_login {{exclude_bots}}
+        and (lower(author_login) {{exclude_bots}})
 )
 
 -- repo group, include bots
@@ -105,7 +105,7 @@ union
 union
 (
     select
-        'pr_opened_company,' || repo_group  || '_include_bot_all_company' as series,
+        'pr_opened_company,' || repo_group  || '_include_bots_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
@@ -116,7 +116,7 @@ union
 union
 (
     select
-        'pr_opened_company,' || repo_group  || '_include_bot_is_top' as series,
+        'pr_opened_company,' || repo_group  || '_include_bots_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
@@ -130,7 +130,7 @@ union
 union
 (
     select
-        'pr_opened_company,' || repo_group  || '_include_bot_not_top' as series,
+        'pr_opened_company,' || repo_group  || '_include_bots_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
@@ -146,12 +146,12 @@ union
 union
 (
     select
-        'pr_opened_company,' || repo_group  || '_exclude_bot_all_company' as series,
+        'pr_opened_company,' || repo_group  || '_exclude_bots_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
     where
-        author_login {{exclude_bots}}
+        lower(author_login) {{exclude_bots}}
     group by
         repo_group
 )
@@ -159,13 +159,13 @@ union
 union
 (
     select
-        'pr_opened_company,' || repo_group  || '_exclude_bot_is_top' as series,
+        'pr_opened_company,' || repo_group  || '_exclude_bots_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
     where
         company_category = 'is-top-contributing-company'
-        and author_login {{exclude_bots}}
+        and (lower(author_login) {{exclude_bots}})
     group by
         repo_group
 )
@@ -173,13 +173,13 @@ union
 union
 (
     select
-        'pr_opened_company,' || repo_group  || '_exclude_bot_not_top' as series,
+        'pr_opened_company,' || repo_group  || '_exclude_bots_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
     where
         company_category = 'not-top-contributing-company'
-        and author_login {{exclude_bots}}
+        and (lower(author_login) {{exclude_bots}})
     group by
         repo_group
 )

--- a/configs/dev/metrics/shared/pr_opened_company.sql
+++ b/configs/dev/metrics/shared/pr_opened_company.sql
@@ -32,7 +32,7 @@ with opened_prs as (
 -- all repositories, include bots, all companies.
 (
     select
-        'pr_opened_company,all_repo_include_bot_all_company' as series,
+        'pr_opened_company,all_include_bot_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
@@ -41,7 +41,7 @@ with opened_prs as (
 union
 (
     select
-        'pr_opened_company,all_repo_include_bot_is_top' as series,
+        'pr_opened_company,all_include_bot_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
@@ -53,7 +53,7 @@ union
 union
 (
     select
-        'pr_opened_company,all_repo_include_bot_not_top' as series,
+        'pr_opened_company,all_include_bot_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
@@ -67,7 +67,7 @@ union
 union
 (
     select
-        'pr_opened_company,all_repo_exclude_bots_all_company' as series,
+        'pr_opened_company,all_exclude_bots_all_company' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
@@ -78,7 +78,7 @@ union
 union
 (
     select
-        'pr_opened_company,all_repo_exclude_bots_is_top' as series,
+        'pr_opened_company,all_exclude_bots_is_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs
@@ -90,7 +90,7 @@ union
 union
 (
     select
-        'pr_opened_company,all_repo_exclude_bots_not_top' as series,
+        'pr_opened_company,all_exclude_bots_not_top' as series,
         round(count(distinct id) / {{n}}, 2) as count
     from
         opened_prs

--- a/configs/dev/metrics/shared/pr_opened_company.sql
+++ b/configs/dev/metrics/shared/pr_opened_company.sql
@@ -1,0 +1,185 @@
+with opened_prs as (
+    select
+        pr.id id,
+        lower(pr.dup_user_login) author_login,
+        r.repo_group repo_group,
+        case when aa.company_name = 'PingCAP' then 'is-top-contributing-company'
+             else 'not-top-contributing-company'
+        end company_category
+    from
+        gha_pull_requests pr
+    left join
+        gha_repos r
+    on
+        r.id = pr.dup_repo_id
+        and r.name = pr.dup_repo_name
+        and r.repo_group is not null
+    left join
+        gha_actors_affiliations aa
+    on
+        aa.actor_id = pr.user_id
+        and aa.dt_from <= pr.created_at
+        and aa.dt_to > pr.created_at
+    where
+        pr.created_at >= '{{from}}'
+        and pr.created_at < '{{to}}'
+        and pr.event_id = (
+            select i.event_id from gha_pull_requests i where i.id = pr.id order by i.updated_at desc limit 1
+        )
+)
+-- all repos, include bots
+
+-- all repositories, include bots, all companies.
+(
+    select
+        'pr_opened_company,all_repo_include_bot_all_company' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        opened_prs
+)
+-- all repositories, include bots, is top contributing company.
+union
+(
+    select
+        'pr_opened_company,all_repo_include_bot_is_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        opened_prs
+    where
+        company_category = 'is-top-contributing-company'
+)
+
+-- all repositories, include bots, not top contributing company.
+union
+(
+    select
+        'pr_opened_company,all_repo_include_bot_not_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        opened_prs
+    where
+        company_category = 'not-top-contributing-company'
+)
+
+-- all repos, exclude bots
+
+-- all repositories, exclude bots, all companies.
+union
+(
+    select
+        'pr_opened_company,all_repo_exclude_bots_all_company' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        opened_prs
+    where
+        author_login {{exclude_bots}}
+)
+-- all repositories, exclude bots, is top contributing company.
+union
+(
+    select
+        'pr_opened_company,all_repo_exclude_bots_is_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        opened_prs
+    where
+        company_category = 'is-top-contributing-company'
+        and author_login {{exclude_bots}}
+)
+-- all repositories, exclude bots, not top contributing company.
+union
+(
+    select
+        'pr_opened_company,all_repo_exclude_bots_not_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        opened_prs
+    where
+        company_category = 'not-top-contributing-company'
+        and author_login {{exclude_bots}}
+)
+
+-- repo group, include bots
+
+-- repository group, include bots, all companies.
+union
+(
+    select
+        'pr_opened_company,' || repo_group  || '_include_bot_all_company' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        opened_prs
+    group by
+        repo_group
+)
+-- repository group, include bots, is top contributing company.
+union
+(
+    select
+        'pr_opened_company,' || repo_group  || '_include_bot_is_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        opened_prs
+    where
+        company_category = 'is-top-contributing-company'
+    group by
+        repo_group
+)
+
+-- repository group, include bots, not top contributing company.
+union
+(
+    select
+        'pr_opened_company,' || repo_group  || '_include_bot_not_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        opened_prs
+    where
+        company_category = 'not-top-contributing-company'
+    group by
+        repo_group
+)
+
+-- repo group, exclude bots
+
+-- repository group, exclude bots, all companies.
+union
+(
+    select
+        'pr_opened_company,' || repo_group  || '_exclude_bot_all_company' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        opened_prs
+    where
+        author_login {{exclude_bots}}
+    group by
+        repo_group
+)
+-- repository group, exclude bots, is top contributing company.
+union
+(
+    select
+        'pr_opened_company,' || repo_group  || '_exclude_bot_is_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        opened_prs
+    where
+        company_category = 'is-top-contributing-company'
+        and author_login {{exclude_bots}}
+    group by
+        repo_group
+)
+-- repository group, exclude bots, not top contributing company.
+union
+(
+    select
+        'pr_opened_company,' || repo_group  || '_exclude_bot_not_top' as series,
+        round(count(distinct id) / {{n}}, 2) as count
+    from
+        opened_prs
+    where
+        company_category = 'not-top-contributing-company'
+        and author_login {{exclude_bots}}
+    group by
+        repo_group
+)

--- a/configs/dev/test/data/test_metrics.yaml
+++ b/configs/dev/test/data/test_metrics.yaml
@@ -1,24 +1,76 @@
 ---
 metrics:
-  - name: Time to first comment on the issue group by company
+  # Contributor
+  - name: New and episodic PR contributors
     series_name_or_func: multi_row_multi_column
-    sql: issue_first_comment_time_company
+    sql: episodic_contributors
+    periods: d,w,m,q,y
+    aggregate: 1,28
+    skip: d,w28,m28,q28,y28
+    merge_series: episodic_contributors
+    drop: sepisodic_contributors
+    
+  - name: New and episodic PR contributors
+    series_name_or_func: multi_row_multi_column
+    sql: new_contributors
+    periods: d,w,m,q,y
+    aggregate: 1,28
+    skip: d,w28,m28,q28,y28
+    merge_series: new_contributors
+    drop: snew_contributors
+
+  # PR Count
+
+  - name: PRs opened group by company
+    series_name_or_func: multi_row_single_column
+    sql: pr_opened_company
     periods: d,w,m,q,y
     aggregate: 1,7
-    skip: d,w7,m7,q7,y7
-    desc: time_diff_as_string
-    merge_series: issue_first_comment_time_company
-    drop: sissue_first_comment_time_company
+    skip: w7,m7,q7,y7
+    merge_series: pr_opened_company
+    drop: spr_opened_company
 
-#  - name: Issues age group by company
-#    series_name_or_func: multi_row_multi_column
-#    sql: issue_age_company
-#    periods: d,w,m,q,y
-#    aggregate: 1,7
-#    skip: w7,m7,q7,y7
-#    desc: time_diff_as_string
-#    merge_series: issue_age_company
-#    drop: sissue_age_company
+  - name: PRs closed group by company
+    series_name_or_func: multi_row_single_column
+    sql: pr_closed_company
+    periods: d,w,m,q,y
+    aggregate: 1,7
+    skip: w7,m7,q7,y7
+    merge_series: pr_closed_company
+    drop: spr_closed_company
+
+  - name: PRs merged group by company
+    series_name_or_func: multi_row_single_column
+    sql: pr_merged_company
+    periods: d,w,m,q,y
+    aggregate: 1,7
+    skip: w7,m7,q7,y7
+    merge_series: pr_merged_company
+    drop: spr_merged_company
+
+  # Issue
+
+  # - name: Time to first comment on the issue group by company
+  #   series_name_or_func: multi_row_multi_column
+  #   sql: issue_first_comment_time_company
+  #   periods: d,w,m,q,y
+  #   aggregate: 1,7
+  #   skip: d,w7,m7,q7,y7
+  #   desc: time_diff_as_string
+  #   merge_series: issue_first_comment_time_company
+  #   drop: sissue_first_comment_time_company
+
+  #  - name: Issues age group by company
+  #    series_name_or_func: multi_row_multi_column
+  #    sql: issue_age_company
+  #    periods: d,w,m,q,y
+  #    aggregate: 1,7
+  #    skip: w7,m7,q7,y7
+  #    desc: time_diff_as_string
+  #    merge_series: issue_age_company
+  #    drop: sissue_age_company
+
+  # PR
 
   #  - name: PR first non-author activity group by company
   #    series_name_or_func: multi_row_multi_column

--- a/configs/prod/grafana/chaosmesh/custom_sqlite.sql
+++ b/configs/prod/grafana/chaosmesh/custom_sqlite.sql
@@ -109,7 +109,9 @@ set
   )
 where
   slug in (
-    'new-prs-in-repository-groups',
+    'prs-opened-in-repository-groups',
+    'prs-merged-in-repository-groups',
+    'prs-closed-in-repository-groups',
     'open-pr-age-by-repository-group',
     'opened-to-merged',
     'pr-reviews-by-contributor',
@@ -117,7 +119,6 @@ where
     'prs-approval-repository-groups',
     'prs-authors-repository-groups',
     'prs-authors-table',
-    'prs-merged-repository-groups',
     'prs-mergers-table',
     'time-to-merge-in-repository-groups'
   )

--- a/configs/prod/grafana/dashboards/chaosmesh/dashboards.json
+++ b/configs/prod/grafana/dashboards/chaosmesh/dashboards.json
@@ -32,7 +32,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 15,
-  "iteration": 1622080154256,
+  "iteration": 1622359473216,
   "links": [
     {
       "icon": "dashboard",
@@ -234,7 +234,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
+        "h": 19,
         "w": 12,
         "x": 0,
         "y": 6
@@ -352,7 +352,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 17,
+        "h": 19,
         "w": 12,
         "x": 12,
         "y": 18
@@ -414,7 +414,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 25
       },
       "id": 8,
       "options": {
@@ -473,7 +473,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 37
       },
       "id": 18,
       "options": {
@@ -528,10 +528,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 37
       },
       "id": 14,
       "options": {
@@ -589,10 +589,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 45
       },
       "id": 16,
       "options": {
@@ -648,10 +648,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 12,
         "x": 12,
-        "y": 49
+        "y": 53
       },
       "id": 4,
       "links": [],
@@ -687,7 +687,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 57
       },
       "id": 6,
       "links": [],
@@ -714,8 +714,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"-full_name-home-dashboard\">ChaosMesh Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/chaosmesh/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://chaosmesh-devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for ChaosMesh project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for ChaosMesh project.</li>\n</ul>",
-          "value": "<h1 id=\"-full_name-home-dashboard\">ChaosMesh Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/chaosmesh/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://chaosmesh-devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for ChaosMesh project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for ChaosMesh project.</li>\n</ul>"
+          "text": "<h1 id=\"-full_name-home-dashboard\">ChaosMesh Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://dev.devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/chaosmesh/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://chaosmesh.dev.devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for ChaosMesh project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for ChaosMesh project.</li>\n</ul>",
+          "value": "<h1 id=\"-full_name-home-dashboard\">ChaosMesh Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://dev.devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/chaosmesh/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://chaosmesh.dev.devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for ChaosMesh project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for ChaosMesh project.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -770,8 +770,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "devstats.tidb.io",
-          "value": "devstats.tidb.io"
+          "text": "dev.devstats.tidb.io",
+          "value": "dev.devstats.tidb.io"
         },
         "datasource": "psql",
         "definition": "",
@@ -829,5 +829,5 @@
   "timezone": "",
   "title": "Dashboards",
   "uid": "8",
-  "version": 2
+  "version": 3
 }

--- a/configs/prod/grafana/dashboards/chaosmesh/new-and-episodic-pr-contributors.json
+++ b/configs/prod/grafana/dashboards/chaosmesh/new-and-episodic-pr-contributors.json
@@ -30,8 +30,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 25,
-  "iteration": 1620638258918,
+  "id": 26,
+  "iteration": 1622353566135,
   "links": [],
   "panels": [
     {
@@ -273,7 +273,8 @@
   "tags": [
     "dashboard",
     "chaosmesh",
-    "issues"
+    "issues",
+    "active"
   ],
   "templating": {
     "list": [
@@ -281,8 +282,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "Chaos Mesh",
-          "value": "Chaos Mesh"
+          "text": "ChaosMesh",
+          "value": "ChaosMesh"
         },
         "datasource": "psql",
         "definition": "",
@@ -410,8 +411,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"dashboard-header\">Chaos Mesh new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
-          "value": "<h1 id=\"dashboard-header\">Chaos Mesh new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
+          "text": "<h1 id=\"dashboard-header\">ChaosMesh new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">ChaosMesh new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",

--- a/configs/prod/grafana/dashboards/chaosmesh/opened-to-merged.json
+++ b/configs/prod/grafana/dashboards/chaosmesh/opened-to-merged.json
@@ -31,7 +31,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 30,
-  "iteration": 1622080414825,
+  "iteration": 1622363662988,
   "links": [],
   "panels": [
     {
@@ -237,7 +237,7 @@
         },
         {
           "$$hashKey": "object:70",
-          "format": "short",
+          "format": "h",
           "label": "Opened to merged (15th percentile)",
           "logBase": 1,
           "max": null,
@@ -580,6 +580,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:76",
           "format": "h",
           "label": "Opened to merged (median & 85th percentile)",
           "logBase": 10,
@@ -588,12 +589,13 @@
           "show": true
         },
         {
+          "$$hashKey": "object:77",
           "format": "short",
           "label": "Opened to merged (15th percentile)",
           "logBase": 1,
           "max": null,
           "min": "0",
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
@@ -630,7 +632,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 39
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 13,
@@ -800,7 +802,7 @@
             },
             {
               "$$hashKey": "object:123",
-              "format": "short",
+              "format": "h",
               "label": "Opened to merged (15th percentile)",
               "logBase": 1,
               "max": null,
@@ -846,7 +848,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 40
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 14,
@@ -1016,7 +1018,7 @@
             },
             {
               "$$hashKey": "object:231",
-              "format": "short",
+              "format": "h",
               "label": "Opened to merged (15th percentile)",
               "logBase": 1,
               "max": null,
@@ -1270,5 +1272,5 @@
   "timezone": "",
   "title": "Opened to Merged",
   "uid": "16",
-  "version": 3
+  "version": 4
 }

--- a/configs/prod/grafana/dashboards/chaosmesh/prs-closed-in-repository-groups.json
+++ b/configs/prod/grafana/dashboards/chaosmesh/prs-closed-in-repository-groups.json
@@ -1,0 +1,883 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": "psql",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Releases",
+        "query": "SELECT title, description from annotations WHERE $timeFilter order by time asc",
+        "rawQuery": "select extract(epoch from time) AS time, title as text, description as tags from sannotations where $__timeFilter(time)",
+        "showIn": 0,
+        "tagsColumn": "title,description",
+        "textColumn": "",
+        "titleColumn": "[[full_name]] release",
+        "type": "alert"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1007,
+  "iteration": 1622365281282,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "psql",
+          "decimals": 0,
+          "description": "The number of new pull requests closed in [[repogroup]] repository group.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 14,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 13,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.0",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "hide": false,
+              "measurement": "reviewers_d",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsistop')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            },
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "hide": false,
+              "measurement": "reviewers_d",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsnottop')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PRs closed ([[repogroup_name]], [[period]], exclude bots)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [
+              "total"
+            ]
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:333",
+              "format": "none",
+              "label": "New PRs",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:334",
+              "format": "none",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "psql",
+          "decimals": 0,
+          "description": "PRs closed in all [[full_name]] repositories",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 5,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.0",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "PRs merged",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "measurement": "all_prs_merged_h",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsallcompany')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PRs closed in all [[full_name]] repositories ([[period]])",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:551",
+              "format": "short",
+              "label": "PRs merged",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:552",
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "PR closed (Not include merged PR)",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 21,
+      "panels": [],
+      "title": "PR closed or merged ",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "The number of pull requests closed or merged in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"The top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsistop')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsistop')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"Not top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsnottop')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsnottop')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PRs closed or merged ([[repogroup_name]], [[period]], exclude bots)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:333",
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:334",
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "PRs closed or merged in all [[full_name]] repositories",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 5,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 17,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "PRs merged",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "measurement": "all_prs_merged_h",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
+          "rawQuery": true,
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"The top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsallcompany')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsallcompany')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PRs closed or merged  in all [[full_name]] repositories ([[period]])",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:551",
+          "format": "short",
+          "label": "PRs merged",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:552",
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "dashboard",
+    "chaosmesh",
+    "active"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "ChaosMesh",
+          "value": "ChaosMesh"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "full_name",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'full_name'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "Day",
+          "value": "d"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Period",
+        "multi": false,
+        "name": "period",
+        "options": [
+          {
+            "selected": true,
+            "text": "Day",
+            "value": "d"
+          },
+          {
+            "selected": false,
+            "text": "7 Days MA",
+            "value": "d7"
+          },
+          {
+            "selected": false,
+            "text": "Week",
+            "value": "w"
+          },
+          {
+            "selected": false,
+            "text": "Month",
+            "value": "m"
+          },
+          {
+            "selected": false,
+            "text": "Quarter",
+            "value": "q"
+          },
+          {
+            "selected": false,
+            "text": "Year",
+            "value": "y"
+          }
+        ],
+        "query": "d,w,m,q,y",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": "all",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": "psql",
+        "definition": "select all_repo_group_name from tall_repo_groups order by 1",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Repository group",
+        "multi": false,
+        "name": "repogroup_name",
+        "options": [],
+        "query": "select all_repo_group_name from tall_repo_groups order by 1",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">ChaosMesh PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">ChaosMesh PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "docs",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'prs_merged_docs_html'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
+        "datasource": null,
+        "definition": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "repogroup",
+        "options": [
+          {
+            "selected": true,
+            "text": "all",
+            "value": "all"
+          }
+        ],
+        "query": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "PRs Closed in Repository Groups",
+  "uid": "pr-closed",
+  "version": 13
+}

--- a/configs/prod/grafana/dashboards/chaosmesh/prs-merged-in-repository-groups.json
+++ b/configs/prod/grafana/dashboards/chaosmesh/prs-merged-in-repository-groups.json
@@ -1,0 +1,573 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": "psql",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Releases",
+        "query": "SELECT title, description from annotations WHERE $timeFilter order by time asc",
+        "rawQuery": "select extract(epoch from time) AS time, title as text, description as tags from sannotations where $__timeFilter(time)",
+        "showIn": 0,
+        "tagsColumn": "title,description",
+        "textColumn": "",
+        "titleColumn": "[[full_name]] release",
+        "type": "alert"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 40,
+  "iteration": 1622365252513,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "Number of new pull requests merged in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_merged_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_merged_company[[repogroup_name]]excludebotsistop')\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_merged_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_merged_company[[repogroup_name]]excludebotsnottop')\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PRs Merged ([[repogroup_name]], [[period]], exclude bots)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:333",
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:334",
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "PRs merged in all [[full_name]] repositories",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 5,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "PRs merged",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "measurement": "all_prs_merged_h",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  \"value\" as \"All PRs merged\"\nfrom\n  sall_prs_merged\nwhere\n  $__timeFilter(time)\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PRs merged in all [[full_name]] repositories ([[period]])",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "PRs merged",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 11,
+      "links": [],
+      "options": {
+        "content": "${docs:raw}",
+        "mode": "html"
+      },
+      "pluginVersion": "7.5.0",
+      "title": "Dashboard documentation",
+      "type": "text"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "dashboard",
+    "chaosmesh",
+    "active"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "ChaosMesh",
+          "value": "ChaosMesh"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "full_name",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'full_name'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "Day",
+          "value": "d"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Period",
+        "multi": false,
+        "name": "period",
+        "options": [
+          {
+            "selected": true,
+            "text": "Day",
+            "value": "d"
+          },
+          {
+            "selected": false,
+            "text": "7 Days MA",
+            "value": "d7"
+          },
+          {
+            "selected": false,
+            "text": "Week",
+            "value": "w"
+          },
+          {
+            "selected": false,
+            "text": "Month",
+            "value": "m"
+          },
+          {
+            "selected": false,
+            "text": "Quarter",
+            "value": "q"
+          },
+          {
+            "selected": false,
+            "text": "Year",
+            "value": "y"
+          }
+        ],
+        "query": "d,w,m,q,y",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": "all",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": "psql",
+        "definition": "select all_repo_group_name from tall_repo_groups order by 1",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Repository group",
+        "multi": false,
+        "name": "repogroup_name",
+        "options": [],
+        "query": "select all_repo_group_name from tall_repo_groups order by 1",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">ChaosMesh PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">ChaosMesh PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "docs",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'prs_merged_docs_html'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
+        "datasource": null,
+        "definition": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "repogroup",
+        "options": [
+          {
+            "selected": true,
+            "text": "all",
+            "value": "all"
+          }
+        ],
+        "query": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "PRs Merged in Repository Groups",
+  "uid": "24",
+  "version": 13
+}

--- a/configs/prod/grafana/dashboards/chaosmesh/prs-opened-in-repository-groups.json
+++ b/configs/prod/grafana/dashboards/chaosmesh/prs-opened-in-repository-groups.json
@@ -1,0 +1,617 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": "psql",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Releases",
+        "query": "SELECT title, description from annotations WHERE $timeFilter order by time asc",
+        "rawQuery": "select extract(epoch from time) AS time, title as text, description as tags from sannotations where $__timeFilter(time)",
+        "showIn": 0,
+        "tagsColumn": "title,description",
+        "textColumn": "",
+        "titleColumn": "[[full_name]] release",
+        "type": "alert"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 28,
+  "iteration": 1622359599936,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "Number of new pull requests created in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_opened_company\nwhere\n  $__timeFilter(time)\n  and series = 'pr_opened_company[[repogroup]]excludebotsistop'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_opened_company\nwhere\n  $__timeFilter(time)\n  and series = 'pr_opened_company[[repogroup]]excludebotsnottop'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "New PRs created ([[repogroup_name]], [[period]], exclude bots)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:333",
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:334",
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "Number of new pull requests created in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 1,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/including bots/",
+          "bars": false,
+          "fill": 0,
+          "lines": true
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"[[repogroup_name]] (excluding bots)\"\nfrom\n  snew_prs\nwhere\n  $__timeFilter(time)\n  and series = 'new_prs[[repogroup]]'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"[[repogroup_name]] (including bots)\"\nfrom\n  snew_prs\nwhere\n  $__timeFilter(time)\n  and series = 'new_prs_bots[[repogroup]]'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "New PRs created in [[repogroup_name]] repository group ([[period]])",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 11,
+      "links": [],
+      "options": {
+        "content": "${docs:raw}",
+        "mode": "html"
+      },
+      "pluginVersion": "7.5.0",
+      "title": "Dashboard documentation",
+      "type": "text"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "dashboard",
+    "chaosmesh",
+    "active"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "7 Days MA",
+          "value": "d7"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Period",
+        "multi": false,
+        "name": "period",
+        "options": [
+          {
+            "selected": true,
+            "text": "7 Days MA",
+            "value": "d7"
+          },
+          {
+            "selected": false,
+            "text": "Day",
+            "value": "d"
+          },
+          {
+            "selected": false,
+            "text": "Week",
+            "value": "w"
+          },
+          {
+            "selected": false,
+            "text": "Month",
+            "value": "m"
+          },
+          {
+            "selected": false,
+            "text": "Quarter",
+            "value": "q"
+          },
+          {
+            "selected": false,
+            "text": "Year",
+            "value": "y"
+          }
+        ],
+        "query": "d,d7,w,m,q,y",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "ChaosMesh",
+          "value": "ChaosMesh"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "full_name",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'full_name'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Repository group",
+        "multi": false,
+        "name": "repogroup_name",
+        "options": [],
+        "query": "select all_repo_group_name from tall_repo_groups order by 1",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "repogroup",
+        "options": [],
+        "query": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">ChaosMesh new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">ChaosMesh new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/chaosmesh/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "docs",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'new_prs_docs_html'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "PRs Opened in Repository Groups",
+  "uid": "15",
+  "version": 7
+}

--- a/configs/prod/grafana/dashboards/pingcap/dashboards.json
+++ b/configs/prod/grafana/dashboards/pingcap/dashboards.json
@@ -32,7 +32,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 15,
-  "iteration": 1622080154256,
+  "iteration": 1622359473216,
   "links": [
     {
       "icon": "dashboard",
@@ -234,7 +234,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
+        "h": 19,
         "w": 12,
         "x": 0,
         "y": 6
@@ -352,7 +352,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 17,
+        "h": 19,
         "w": 12,
         "x": 12,
         "y": 18
@@ -414,7 +414,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 25
       },
       "id": 8,
       "options": {
@@ -473,7 +473,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 37
       },
       "id": 18,
       "options": {
@@ -528,10 +528,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 37
       },
       "id": 14,
       "options": {
@@ -589,10 +589,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 45
       },
       "id": 16,
       "options": {
@@ -648,10 +648,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 12,
         "x": 12,
-        "y": 49
+        "y": 53
       },
       "id": 4,
       "links": [],
@@ -687,7 +687,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 57
       },
       "id": 6,
       "links": [],
@@ -714,8 +714,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"-full_name-home-dashboard\">PingCAP Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/pingcap/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://pingcap-devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for PingCAP project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for PingCAP project.</li>\n</ul>",
-          "value": "<h1 id=\"-full_name-home-dashboard\">PingCAP Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/pingcap/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://pingcap-devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for PingCAP project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for PingCAP project.</li>\n</ul>"
+          "text": "<h1 id=\"-full_name-home-dashboard\">PingCAP Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://dev.devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/pingcap/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://pingcap.dev.devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for PingCAP project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for PingCAP project.</li>\n</ul>",
+          "value": "<h1 id=\"-full_name-home-dashboard\">PingCAP Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://dev.devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/pingcap/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://pingcap.dev.devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for PingCAP project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for PingCAP project.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -770,8 +770,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "devstats.tidb.io",
-          "value": "devstats.tidb.io"
+          "text": "dev.devstats.tidb.io",
+          "value": "dev.devstats.tidb.io"
         },
         "datasource": "psql",
         "definition": "",
@@ -829,5 +829,5 @@
   "timezone": "",
   "title": "Dashboards",
   "uid": "8",
-  "version": 2
+  "version": 3
 }

--- a/configs/prod/grafana/dashboards/pingcap/new-and-episodic-pr-contributors.json
+++ b/configs/prod/grafana/dashboards/pingcap/new-and-episodic-pr-contributors.json
@@ -30,8 +30,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 20,
-  "iteration": 1533289967018,
+  "id": 26,
+  "iteration": 1622353566135,
   "links": [],
   "panels": [
     {
@@ -42,13 +42,19 @@
       "datasource": "psql",
       "decimals": 0,
       "description": "Displays the number of new/episodic issues and the number of new/episodic issues authors.\nThe episodic author is defined as someone who hasn't created issue in the last 3 months and no more than 12 issues overall.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 22,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 1,
       "legend": {
         "alignAsTable": false,
@@ -67,7 +73,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.0",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -192,6 +202,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "New/episodic issues ([[repogroup_name]], [[period]])",
       "tooltip": {
@@ -234,7 +245,11 @@
       }
     },
     {
-      "content": "${docs:raw}",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 13,
         "w": 24,
@@ -243,25 +258,37 @@
       },
       "id": 11,
       "links": [],
-      "mode": "html",
+      "options": {
+        "content": "${docs:raw}",
+        "mode": "html"
+      },
+      "pluginVersion": "7.5.0",
       "title": "Dashboard documentation",
       "type": "text"
     }
   ],
   "refresh": false,
-  "schemaVersion": 16,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "dashboard",
     "pingcap",
-    "issues"
+    "issues",
+    "active"
   ],
   "templating": {
     "list": [
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "PingCAP",
+          "value": "PingCAP"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -286,6 +313,8 @@
           "text": "28 Days MA",
           "value": "d28"
         },
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Period",
@@ -324,8 +353,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Repository group",
@@ -345,8 +381,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -366,8 +409,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">PingCAP new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">PingCAP new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -388,7 +438,7 @@
     ]
   },
   "time": {
-    "from": "now-3y",
+    "from": "now-1y",
     "to": "now-1M"
   },
   "timepicker": {

--- a/configs/prod/grafana/dashboards/pingcap/opened-to-merged.json
+++ b/configs/prod/grafana/dashboards/pingcap/opened-to-merged.json
@@ -31,7 +31,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 30,
-  "iteration": 1622080414825,
+  "iteration": 1622363662988,
   "links": [],
   "panels": [
     {
@@ -237,7 +237,7 @@
         },
         {
           "$$hashKey": "object:70",
-          "format": "short",
+          "format": "h",
           "label": "Opened to merged (15th percentile)",
           "logBase": 1,
           "max": null,
@@ -580,6 +580,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:76",
           "format": "h",
           "label": "Opened to merged (median & 85th percentile)",
           "logBase": 10,
@@ -588,12 +589,13 @@
           "show": true
         },
         {
+          "$$hashKey": "object:77",
           "format": "short",
           "label": "Opened to merged (15th percentile)",
           "logBase": 1,
           "max": null,
           "min": "0",
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
@@ -630,7 +632,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 39
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 13,
@@ -800,7 +802,7 @@
             },
             {
               "$$hashKey": "object:123",
-              "format": "short",
+              "format": "h",
               "label": "Opened to merged (15th percentile)",
               "logBase": 1,
               "max": null,
@@ -846,7 +848,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 40
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 14,
@@ -1016,7 +1018,7 @@
             },
             {
               "$$hashKey": "object:231",
-              "format": "short",
+              "format": "h",
               "label": "Opened to merged (15th percentile)",
               "logBase": 1,
               "max": null,
@@ -1270,5 +1272,5 @@
   "timezone": "",
   "title": "Opened to Merged",
   "uid": "16",
-  "version": 3
+  "version": 4
 }

--- a/configs/prod/grafana/dashboards/pingcap/prs-closed-in-repository-groups.json
+++ b/configs/prod/grafana/dashboards/pingcap/prs-closed-in-repository-groups.json
@@ -1,0 +1,883 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": "psql",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Releases",
+        "query": "SELECT title, description from annotations WHERE $timeFilter order by time asc",
+        "rawQuery": "select extract(epoch from time) AS time, title as text, description as tags from sannotations where $__timeFilter(time)",
+        "showIn": 0,
+        "tagsColumn": "title,description",
+        "textColumn": "",
+        "titleColumn": "[[full_name]] release",
+        "type": "alert"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1007,
+  "iteration": 1622365281282,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "psql",
+          "decimals": 0,
+          "description": "The number of new pull requests closed in [[repogroup]] repository group.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 14,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 13,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.0",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "hide": false,
+              "measurement": "reviewers_d",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsistop')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            },
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "hide": false,
+              "measurement": "reviewers_d",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsnottop')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PRs closed ([[repogroup_name]], [[period]], exclude bots)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [
+              "total"
+            ]
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:333",
+              "format": "none",
+              "label": "New PRs",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:334",
+              "format": "none",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "psql",
+          "decimals": 0,
+          "description": "PRs closed in all [[full_name]] repositories",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 5,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.0",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "PRs merged",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "measurement": "all_prs_merged_h",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsallcompany')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PRs closed in all [[full_name]] repositories ([[period]])",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:551",
+              "format": "short",
+              "label": "PRs merged",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:552",
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "PR closed (Not include merged PR)",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 21,
+      "panels": [],
+      "title": "PR closed or merged ",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "The number of pull requests closed or merged in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"The top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsistop')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsistop')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"Not top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsnottop')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsnottop')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PRs closed or merged ([[repogroup_name]], [[period]], exclude bots)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:333",
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:334",
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "PRs closed or merged in all [[full_name]] repositories",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 5,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 17,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "PRs merged",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "measurement": "all_prs_merged_h",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
+          "rawQuery": true,
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"The top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsallcompany')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsallcompany')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PRs closed or merged  in all [[full_name]] repositories ([[period]])",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:551",
+          "format": "short",
+          "label": "PRs merged",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:552",
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "dashboard",
+    "pingcap",
+    "active"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "PingCAP",
+          "value": "PingCAP"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "full_name",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'full_name'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "Day",
+          "value": "d"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Period",
+        "multi": false,
+        "name": "period",
+        "options": [
+          {
+            "selected": true,
+            "text": "Day",
+            "value": "d"
+          },
+          {
+            "selected": false,
+            "text": "7 Days MA",
+            "value": "d7"
+          },
+          {
+            "selected": false,
+            "text": "Week",
+            "value": "w"
+          },
+          {
+            "selected": false,
+            "text": "Month",
+            "value": "m"
+          },
+          {
+            "selected": false,
+            "text": "Quarter",
+            "value": "q"
+          },
+          {
+            "selected": false,
+            "text": "Year",
+            "value": "y"
+          }
+        ],
+        "query": "d,w,m,q,y",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": "all",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": "psql",
+        "definition": "select all_repo_group_name from tall_repo_groups order by 1",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Repository group",
+        "multi": false,
+        "name": "repogroup_name",
+        "options": [],
+        "query": "select all_repo_group_name from tall_repo_groups order by 1",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">PingCAP PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">PingCAP PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "docs",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'prs_merged_docs_html'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
+        "datasource": null,
+        "definition": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "repogroup",
+        "options": [
+          {
+            "selected": true,
+            "text": "all",
+            "value": "all"
+          }
+        ],
+        "query": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "PRs Closed in Repository Groups",
+  "uid": "pr-closed",
+  "version": 13
+}

--- a/configs/prod/grafana/dashboards/pingcap/prs-merged-in-repository-groups.json
+++ b/configs/prod/grafana/dashboards/pingcap/prs-merged-in-repository-groups.json
@@ -1,0 +1,573 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": "psql",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Releases",
+        "query": "SELECT title, description from annotations WHERE $timeFilter order by time asc",
+        "rawQuery": "select extract(epoch from time) AS time, title as text, description as tags from sannotations where $__timeFilter(time)",
+        "showIn": 0,
+        "tagsColumn": "title,description",
+        "textColumn": "",
+        "titleColumn": "[[full_name]] release",
+        "type": "alert"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 40,
+  "iteration": 1622365252513,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "Number of new pull requests merged in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_merged_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_merged_company[[repogroup_name]]excludebotsistop')\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_merged_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_merged_company[[repogroup_name]]excludebotsnottop')\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PRs Merged ([[repogroup_name]], [[period]], exclude bots)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:333",
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:334",
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "PRs merged in all [[full_name]] repositories",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 5,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "PRs merged",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "measurement": "all_prs_merged_h",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  \"value\" as \"All PRs merged\"\nfrom\n  sall_prs_merged\nwhere\n  $__timeFilter(time)\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PRs merged in all [[full_name]] repositories ([[period]])",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "PRs merged",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 11,
+      "links": [],
+      "options": {
+        "content": "${docs:raw}",
+        "mode": "html"
+      },
+      "pluginVersion": "7.5.0",
+      "title": "Dashboard documentation",
+      "type": "text"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "dashboard",
+    "pingcap",
+    "active"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "PingCAP",
+          "value": "PingCAP"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "full_name",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'full_name'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "Day",
+          "value": "d"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Period",
+        "multi": false,
+        "name": "period",
+        "options": [
+          {
+            "selected": true,
+            "text": "Day",
+            "value": "d"
+          },
+          {
+            "selected": false,
+            "text": "7 Days MA",
+            "value": "d7"
+          },
+          {
+            "selected": false,
+            "text": "Week",
+            "value": "w"
+          },
+          {
+            "selected": false,
+            "text": "Month",
+            "value": "m"
+          },
+          {
+            "selected": false,
+            "text": "Quarter",
+            "value": "q"
+          },
+          {
+            "selected": false,
+            "text": "Year",
+            "value": "y"
+          }
+        ],
+        "query": "d,w,m,q,y",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": "all",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": "psql",
+        "definition": "select all_repo_group_name from tall_repo_groups order by 1",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Repository group",
+        "multi": false,
+        "name": "repogroup_name",
+        "options": [],
+        "query": "select all_repo_group_name from tall_repo_groups order by 1",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">PingCAP PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">PingCAP PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "docs",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'prs_merged_docs_html'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
+        "datasource": null,
+        "definition": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "repogroup",
+        "options": [
+          {
+            "selected": true,
+            "text": "all",
+            "value": "all"
+          }
+        ],
+        "query": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "PRs Merged in Repository Groups",
+  "uid": "24",
+  "version": 13
+}

--- a/configs/prod/grafana/dashboards/pingcap/prs-opened-in-repository-groups.json
+++ b/configs/prod/grafana/dashboards/pingcap/prs-opened-in-repository-groups.json
@@ -1,0 +1,617 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": "psql",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Releases",
+        "query": "SELECT title, description from annotations WHERE $timeFilter order by time asc",
+        "rawQuery": "select extract(epoch from time) AS time, title as text, description as tags from sannotations where $__timeFilter(time)",
+        "showIn": 0,
+        "tagsColumn": "title,description",
+        "textColumn": "",
+        "titleColumn": "[[full_name]] release",
+        "type": "alert"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 28,
+  "iteration": 1622359599936,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "Number of new pull requests created in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_opened_company\nwhere\n  $__timeFilter(time)\n  and series = 'pr_opened_company[[repogroup]]excludebotsistop'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_opened_company\nwhere\n  $__timeFilter(time)\n  and series = 'pr_opened_company[[repogroup]]excludebotsnottop'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "New PRs created ([[repogroup_name]], [[period]], exclude bots)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:333",
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:334",
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "Number of new pull requests created in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 1,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/including bots/",
+          "bars": false,
+          "fill": 0,
+          "lines": true
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"[[repogroup_name]] (excluding bots)\"\nfrom\n  snew_prs\nwhere\n  $__timeFilter(time)\n  and series = 'new_prs[[repogroup]]'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"[[repogroup_name]] (including bots)\"\nfrom\n  snew_prs\nwhere\n  $__timeFilter(time)\n  and series = 'new_prs_bots[[repogroup]]'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "New PRs created in [[repogroup_name]] repository group ([[period]])",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 11,
+      "links": [],
+      "options": {
+        "content": "${docs:raw}",
+        "mode": "html"
+      },
+      "pluginVersion": "7.5.0",
+      "title": "Dashboard documentation",
+      "type": "text"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "dashboard",
+    "pingcap",
+    "active"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "7 Days MA",
+          "value": "d7"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Period",
+        "multi": false,
+        "name": "period",
+        "options": [
+          {
+            "selected": true,
+            "text": "7 Days MA",
+            "value": "d7"
+          },
+          {
+            "selected": false,
+            "text": "Day",
+            "value": "d"
+          },
+          {
+            "selected": false,
+            "text": "Week",
+            "value": "w"
+          },
+          {
+            "selected": false,
+            "text": "Month",
+            "value": "m"
+          },
+          {
+            "selected": false,
+            "text": "Quarter",
+            "value": "q"
+          },
+          {
+            "selected": false,
+            "text": "Year",
+            "value": "y"
+          }
+        ],
+        "query": "d,d7,w,m,q,y",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "PingCAP",
+          "value": "PingCAP"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "full_name",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'full_name'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Repository group",
+        "multi": false,
+        "name": "repogroup_name",
+        "options": [],
+        "query": "select all_repo_group_name from tall_repo_groups order by 1",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "repogroup",
+        "options": [],
+        "query": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">PingCAP new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">PingCAP new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/pingcap/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "docs",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'new_prs_docs_html'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "PRs Opened in Repository Groups",
+  "uid": "15",
+  "version": 7
+}

--- a/configs/prod/grafana/dashboards/tikv/dashboards.json
+++ b/configs/prod/grafana/dashboards/tikv/dashboards.json
@@ -32,7 +32,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 15,
-  "iteration": 1622080154256,
+  "iteration": 1622359473216,
   "links": [
     {
       "icon": "dashboard",
@@ -234,7 +234,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 14,
+        "h": 19,
         "w": 12,
         "x": 0,
         "y": 6
@@ -352,7 +352,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 17,
+        "h": 19,
         "w": 12,
         "x": 12,
         "y": 18
@@ -414,7 +414,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 25
       },
       "id": 8,
       "options": {
@@ -473,7 +473,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 37
       },
       "id": 18,
       "options": {
@@ -528,10 +528,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 37
       },
       "id": 14,
       "options": {
@@ -589,10 +589,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 45
       },
       "id": 16,
       "options": {
@@ -648,10 +648,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
+        "h": 4,
         "w": 12,
         "x": 12,
-        "y": 49
+        "y": 53
       },
       "id": 4,
       "links": [],
@@ -687,7 +687,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 57
       },
       "id": 6,
       "links": [],
@@ -714,8 +714,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "<h1 id=\"-full_name-home-dashboard\">TiKV Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/tikv/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://tikv-devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for TiKV project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for TiKV project.</li>\n</ul>",
-          "value": "<h1 id=\"-full_name-home-dashboard\">TiKV Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/tikv/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://tikv-devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for TiKV project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for TiKV project.</li>\n</ul>"
+          "text": "<h1 id=\"-full_name-home-dashboard\">TiKV Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://dev.devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/tikv/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://tikv.dev.devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for TiKV project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for TiKV project.</li>\n</ul>",
+          "value": "<h1 id=\"-full_name-home-dashboard\">TiKV Home dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Postgres <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/events.sql\" target=\"_blank\">SQL file</a>, database <a href=\"https://dev.devstats.tidb.io/backups\" target=\"_blank\">dumps</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/tikv/metrics.yaml\" target=\"_blank\">series definition</a> (search for <code>name: GitHub activity</code>).</li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/dashboards.json\" target=\"_blank\">JSON</a>.</li>\n<li>Developer <a href=\"https://github.com/cncf/devstats/blob/master/docs/dashboards/dashboards_devel.md\" target=\"_blank\">documentation</a>.</li>\n<li>Direct <a href=\"https://tikv.dev.devstats.tidb.io\" target=\"_blank\">link</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>First we&#39;re displaying links to all CNCF projects defined.</li>\n<li>Next we&#39;re showing current project&#39;s hourly activity - this is the number of all GitHub events that happened for TiKV project hourly.</li>\n<li>This also includes bots activity (most other dashboards skip bot activity).</li>\n<li>Next we&#39;re showing HTML panel that shows all CNCF projects icons and links.</li>\n<li>Next there is a dashboard that shows a list of all dashboards defined for TiKV project.</li>\n</ul>"
         },
         "datasource": "psql",
         "definition": "",
@@ -770,8 +770,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "devstats.tidb.io",
-          "value": "devstats.tidb.io"
+          "text": "dev.devstats.tidb.io",
+          "value": "dev.devstats.tidb.io"
         },
         "datasource": "psql",
         "definition": "",
@@ -829,5 +829,5 @@
   "timezone": "",
   "title": "Dashboards",
   "uid": "8",
-  "version": 2
+  "version": 3
 }

--- a/configs/prod/grafana/dashboards/tikv/new-and-episodic-pr-contributors.json
+++ b/configs/prod/grafana/dashboards/tikv/new-and-episodic-pr-contributors.json
@@ -30,8 +30,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 20,
-  "iteration": 1533289967018,
+  "id": 26,
+  "iteration": 1622353566135,
   "links": [],
   "panels": [
     {
@@ -42,13 +42,19 @@
       "datasource": "psql",
       "decimals": 0,
       "description": "Displays the number of new/episodic issues and the number of new/episodic issues authors.\nThe episodic author is defined as someone who hasn't created issue in the last 3 months and no more than 12 issues overall.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 1,
+      "fillGradient": 0,
       "gridPos": {
         "h": 22,
         "w": 24,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 1,
       "legend": {
         "alignAsTable": false,
@@ -67,7 +73,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.0",
       "pointradius": 1,
       "points": false,
       "renderer": "flot",
@@ -192,6 +202,7 @@
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
       "title": "New/episodic issues ([[repogroup_name]], [[period]])",
       "tooltip": {
@@ -234,7 +245,11 @@
       }
     },
     {
-      "content": "${docs:raw}",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 13,
         "w": 24,
@@ -243,25 +258,37 @@
       },
       "id": 11,
       "links": [],
-      "mode": "html",
+      "options": {
+        "content": "${docs:raw}",
+        "mode": "html"
+      },
+      "pluginVersion": "7.5.0",
       "title": "Dashboard documentation",
       "type": "text"
     }
   ],
   "refresh": false,
-  "schemaVersion": 16,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "dashboard",
     "tikv",
-    "issues"
+    "issues",
+    "active"
   ],
   "templating": {
     "list": [
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "TiKV",
+          "value": "TiKV"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -286,6 +313,8 @@
           "text": "28 Days MA",
           "value": "d28"
         },
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Period",
@@ -324,8 +353,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": false,
         "label": "Repository group",
@@ -345,8 +381,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -366,8 +409,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">TiKV new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">TiKV new and episodic PR contributors dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>New contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>Episodic contributors metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/episodic_contributors.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>New and episodic PR contributors</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/new-and-episodic-pr-contributors.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows statistics about new and episodic PRs and contributors (PR creators).</li>\n<li>New contributor (PR creator) is someone who haven't created any PR before given period.</li>\n<li>New PR is a PR created by new contributor</li>\n<li>Episodic contributor (PR creator) is someone who haven't created any PR in 3 months before given project and haven't created more than 12 PRs overall.</li>\n<li>Episodic PR is a PR created by episodic contributor.</li>\n<li>You can select single repository group or summary for all of them.</li>\n<li>Selecting period (for example week) means that dashboard will calculate statistics in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
+        },
         "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": null,
@@ -388,7 +438,7 @@
     ]
   },
   "time": {
-    "from": "now-3y",
+    "from": "now-1y",
     "to": "now-1M"
   },
   "timepicker": {

--- a/configs/prod/grafana/dashboards/tikv/opened-to-merged.json
+++ b/configs/prod/grafana/dashboards/tikv/opened-to-merged.json
@@ -31,7 +31,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 30,
-  "iteration": 1622080414825,
+  "iteration": 1622363662988,
   "links": [],
   "panels": [
     {
@@ -237,7 +237,7 @@
         },
         {
           "$$hashKey": "object:70",
-          "format": "short",
+          "format": "h",
           "label": "Opened to merged (15th percentile)",
           "logBase": 1,
           "max": null,
@@ -580,6 +580,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:76",
           "format": "h",
           "label": "Opened to merged (median & 85th percentile)",
           "logBase": 10,
@@ -588,12 +589,13 @@
           "show": true
         },
         {
+          "$$hashKey": "object:77",
           "format": "short",
           "label": "Opened to merged (15th percentile)",
           "logBase": 1,
           "max": null,
           "min": "0",
-          "show": true
+          "show": false
         }
       ],
       "yaxis": {
@@ -630,7 +632,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 39
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 13,
@@ -800,7 +802,7 @@
             },
             {
               "$$hashKey": "object:123",
-              "format": "short",
+              "format": "h",
               "label": "Opened to merged (15th percentile)",
               "logBase": 1,
               "max": null,
@@ -846,7 +848,7 @@
             "h": 13,
             "w": 24,
             "x": 0,
-            "y": 40
+            "y": 41
           },
           "hiddenSeries": false,
           "id": 14,
@@ -1016,7 +1018,7 @@
             },
             {
               "$$hashKey": "object:231",
-              "format": "short",
+              "format": "h",
               "label": "Opened to merged (15th percentile)",
               "logBase": 1,
               "max": null,
@@ -1270,5 +1272,5 @@
   "timezone": "",
   "title": "Opened to Merged",
   "uid": "16",
-  "version": 3
+  "version": 4
 }

--- a/configs/prod/grafana/dashboards/tikv/prs-closed-in-repository-groups.json
+++ b/configs/prod/grafana/dashboards/tikv/prs-closed-in-repository-groups.json
@@ -1,0 +1,883 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": "psql",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Releases",
+        "query": "SELECT title, description from annotations WHERE $timeFilter order by time asc",
+        "rawQuery": "select extract(epoch from time) AS time, title as text, description as tags from sannotations where $__timeFilter(time)",
+        "showIn": 0,
+        "tagsColumn": "title,description",
+        "textColumn": "",
+        "titleColumn": "[[full_name]] release",
+        "type": "alert"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1007,
+  "iteration": 1622365281282,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "psql",
+          "decimals": 0,
+          "description": "The number of new pull requests closed in [[repogroup]] repository group.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 14,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 13,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.0",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "hide": false,
+              "measurement": "reviewers_d",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsistop')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            },
+            {
+              "alias": "",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "hide": false,
+              "measurement": "reviewers_d",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "autogen",
+              "query": "",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsnottop')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PRs closed ([[repogroup_name]], [[period]], exclude bots)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [
+              "total"
+            ]
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:333",
+              "format": "none",
+              "label": "New PRs",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:334",
+              "format": "none",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "psql",
+          "decimals": 0,
+          "description": "PRs closed in all [[full_name]] repositories",
+          "fieldConfig": {
+            "defaults": {},
+            "overrides": []
+          },
+          "fill": 5,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 12,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 3,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.5.0",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "PRs merged",
+              "dsType": "influxdb",
+              "format": "time_series",
+              "group": [],
+              "groupBy": [],
+              "measurement": "all_prs_merged_h",
+              "metricColumn": "none",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
+              "rawQuery": true,
+              "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_closed_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_closed_company[[repogroup_name]]excludebotsallcompany')\n  and period = '[[period]]'\norder by\n  time",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  }
+                ]
+              ],
+              "tags": [],
+              "timeColumn": "time",
+              "where": [
+                {
+                  "name": "$__timeFilter",
+                  "params": [],
+                  "type": "macro"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "PRs closed in all [[full_name]] repositories ([[period]])",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:551",
+              "format": "short",
+              "label": "PRs merged",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "$$hashKey": "object:552",
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "PR closed (Not include merged PR)",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 21,
+      "panels": [],
+      "title": "PR closed or merged ",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "The number of pull requests closed or merged in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"The top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsistop')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsistop')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"Not top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsnottop')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsnottop')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PRs closed or merged ([[repogroup_name]], [[period]], exclude bots)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:333",
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:334",
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "PRs closed or merged in all [[full_name]] repositories",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 5,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 17,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "PRs merged",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "measurement": "all_prs_merged_h",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
+          "rawQuery": true,
+          "rawSql": "select\n  sub.time,\n  sum(sub.value) as \"The top contribuing company\"\nfrom (\n  (\n    select\n      time,\n      value\n    from\n      spr_closed_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_closed_company[[repogroup_name]]excludebotsallcompany')\n      and period = '[[period]]'\n  )\n  union\n  (\n    select\n      time,\n      value\n    from\n      spr_merged_company\n    where\n      $__timeFilter(time)\n      and series = lower('pr_merged_company[[repogroup_name]]excludebotsallcompany')\n      and period = '[[period]]'\n  )\n) sub\ngroup by time\norder by time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PRs closed or merged  in all [[full_name]] repositories ([[period]])",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:551",
+          "format": "short",
+          "label": "PRs merged",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:552",
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "dashboard",
+    "tikv",
+    "active"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "TiKV",
+          "value": "TiKV"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "full_name",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'full_name'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "Day",
+          "value": "d"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Period",
+        "multi": false,
+        "name": "period",
+        "options": [
+          {
+            "selected": true,
+            "text": "Day",
+            "value": "d"
+          },
+          {
+            "selected": false,
+            "text": "7 Days MA",
+            "value": "d7"
+          },
+          {
+            "selected": false,
+            "text": "Week",
+            "value": "w"
+          },
+          {
+            "selected": false,
+            "text": "Month",
+            "value": "m"
+          },
+          {
+            "selected": false,
+            "text": "Quarter",
+            "value": "q"
+          },
+          {
+            "selected": false,
+            "text": "Year",
+            "value": "y"
+          }
+        ],
+        "query": "d,w,m,q,y",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": "all",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": "psql",
+        "definition": "select all_repo_group_name from tall_repo_groups order by 1",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Repository group",
+        "multi": false,
+        "name": "repogroup_name",
+        "options": [],
+        "query": "select all_repo_group_name from tall_repo_groups order by 1",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">TiKV PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">TiKV PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "docs",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'prs_merged_docs_html'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
+        "datasource": null,
+        "definition": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "repogroup",
+        "options": [
+          {
+            "selected": true,
+            "text": "all",
+            "value": "all"
+          }
+        ],
+        "query": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "PRs Closed in Repository Groups",
+  "uid": "pr-closed",
+  "version": 13
+}

--- a/configs/prod/grafana/dashboards/tikv/prs-merged-in-repository-groups.json
+++ b/configs/prod/grafana/dashboards/tikv/prs-merged-in-repository-groups.json
@@ -1,0 +1,573 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": "psql",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Releases",
+        "query": "SELECT title, description from annotations WHERE $timeFilter order by time asc",
+        "rawQuery": "select extract(epoch from time) AS time, title as text, description as tags from sannotations where $__timeFilter(time)",
+        "showIn": 0,
+        "tagsColumn": "title,description",
+        "textColumn": "",
+        "titleColumn": "[[full_name]] release",
+        "type": "alert"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 40,
+  "iteration": 1622365252513,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "Number of new pull requests merged in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_merged_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_merged_company[[repogroup_name]]excludebotsistop')\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_merged_company\nwhere\n  $__timeFilter(time)\n  and series = lower('pr_merged_company[[repogroup_name]]excludebotsnottop')\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PRs Merged ([[repogroup_name]], [[period]], exclude bots)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:333",
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:334",
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "PRs merged in all [[full_name]] repositories",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 5,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "hiddenSeries": false,
+      "id": 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "PRs merged",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "measurement": "all_prs_merged_h",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT \"value\" FROM \"all_prs_merged_[[period]]\" WHERE $timeFilter",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  \"value\" as \"All PRs merged\"\nfrom\n  sall_prs_merged\nwhere\n  $__timeFilter(time)\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PRs merged in all [[full_name]] repositories ([[period]])",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "PRs merged",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 11,
+      "links": [],
+      "options": {
+        "content": "${docs:raw}",
+        "mode": "html"
+      },
+      "pluginVersion": "7.5.0",
+      "title": "Dashboard documentation",
+      "type": "text"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "dashboard",
+    "tikv",
+    "active"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "TiKV",
+          "value": "TiKV"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "full_name",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'full_name'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "Day",
+          "value": "d"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Period",
+        "multi": false,
+        "name": "period",
+        "options": [
+          {
+            "selected": true,
+            "text": "Day",
+            "value": "d"
+          },
+          {
+            "selected": false,
+            "text": "7 Days MA",
+            "value": "d7"
+          },
+          {
+            "selected": false,
+            "text": "Week",
+            "value": "w"
+          },
+          {
+            "selected": false,
+            "text": "Month",
+            "value": "m"
+          },
+          {
+            "selected": false,
+            "text": "Quarter",
+            "value": "q"
+          },
+          {
+            "selected": false,
+            "text": "Year",
+            "value": "y"
+          }
+        ],
+        "query": "d,w,m,q,y",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": "all",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": "psql",
+        "definition": "select all_repo_group_name from tall_repo_groups order by 1",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Repository group",
+        "multi": false,
+        "name": "repogroup_name",
+        "options": [],
+        "query": "select all_repo_group_name from tall_repo_groups order by 1",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">TiKV PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">TiKV PRs merged repository groups dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/prs_merged_groups.sql\" target=\"_blank\">SQL file</a> (repo groups).</li>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/all_prs_merged.sql\" target=\"_blank\">SQL file</a> (all PRs merged).</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>prs_merged_groups</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/prs-merged-repository-groups.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows number of PRs merged in given periods in selected repository groups.</li>\n<li>One panel shows stacked number of PRs merged in selected repositories. Second panel shows chart for all PRs merged in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will show PRs merged in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n<li>We are skipping bots activity, see <a href=\"https://github.com/cncf/devstats/blob/master/docs/excluding_bots.md\" target=\"_blank\">excluding bots</a> for details.</li>\n</ul>"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "docs",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'prs_merged_docs_html'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
+        "datasource": null,
+        "definition": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "repogroup",
+        "options": [
+          {
+            "selected": true,
+            "text": "all",
+            "value": "all"
+          }
+        ],
+        "query": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "PRs Merged in Repository Groups",
+  "uid": "24",
+  "version": 13
+}

--- a/configs/prod/grafana/dashboards/tikv/prs-opened-in-repository-groups.json
+++ b/configs/prod/grafana/dashboards/tikv/prs-opened-in-repository-groups.json
@@ -1,0 +1,617 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": "psql",
+        "enable": true,
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "Releases",
+        "query": "SELECT title, description from annotations WHERE $timeFilter order by time asc",
+        "rawQuery": "select extract(epoch from time) AS time, title as text, description as tags from sannotations where $__timeFilter(time)",
+        "showIn": 0,
+        "tagsColumn": "title,description",
+        "textColumn": "",
+        "titleColumn": "[[full_name]] release",
+        "type": "alert"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 28,
+  "iteration": 1622359599936,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "Number of new pull requests created in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"The top contribuing company\"\nfrom\n  spr_opened_company\nwhere\n  $__timeFilter(time)\n  and series = 'pr_opened_company[[repogroup]]excludebotsistop'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"Not top contribuing company\"\nfrom\n  spr_opened_company\nwhere\n  $__timeFilter(time)\n  and series = 'pr_opened_company[[repogroup]]excludebotsnottop'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "New PRs created ([[repogroup_name]], [[period]], exclude bots)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:333",
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:334",
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "psql",
+      "decimals": 0,
+      "description": "Number of new pull requests created in [[repogroup]] repository group.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 1,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": true,
+        "values": true
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.0",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/including bots/",
+          "bars": false,
+          "fill": 0,
+          "lines": true
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"[[repogroup_name]] (excluding bots)\"\nfrom\n  snew_prs\nwhere\n  $__timeFilter(time)\n  and series = 'new_prs[[repogroup]]'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        },
+        {
+          "alias": "",
+          "dsType": "influxdb",
+          "format": "time_series",
+          "group": [],
+          "groupBy": [],
+          "hide": false,
+          "measurement": "reviewers_d",
+          "metricColumn": "none",
+          "orderByTime": "ASC",
+          "policy": "autogen",
+          "query": "",
+          "rawQuery": true,
+          "rawSql": "select\n  time,\n  value as \"[[repogroup_name]] (including bots)\"\nfrom\n  snew_prs\nwhere\n  $__timeFilter(time)\n  and series = 'new_prs_bots[[repogroup]]'\n  and period = '[[period]]'\norder by\n  time",
+          "refId": "B",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "tags": [],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "New PRs created in [[repogroup_name]] repository group ([[period]])",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": [
+          "total"
+        ]
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": "New PRs",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 11,
+      "links": [],
+      "options": {
+        "content": "${docs:raw}",
+        "mode": "html"
+      },
+      "pluginVersion": "7.5.0",
+      "title": "Dashboard documentation",
+      "type": "text"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [
+    "dashboard",
+    "tikv",
+    "active"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "7 Days MA",
+          "value": "d7"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Period",
+        "multi": false,
+        "name": "period",
+        "options": [
+          {
+            "selected": true,
+            "text": "7 Days MA",
+            "value": "d7"
+          },
+          {
+            "selected": false,
+            "text": "Day",
+            "value": "d"
+          },
+          {
+            "selected": false,
+            "text": "Week",
+            "value": "w"
+          },
+          {
+            "selected": false,
+            "text": "Month",
+            "value": "m"
+          },
+          {
+            "selected": false,
+            "text": "Quarter",
+            "value": "q"
+          },
+          {
+            "selected": false,
+            "text": "Year",
+            "value": "y"
+          }
+        ],
+        "query": "d,d7,w,m,q,y",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "TiKV",
+          "value": "TiKV"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "full_name",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'full_name'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Repository group",
+        "multi": false,
+        "name": "repogroup_name",
+        "options": [],
+        "query": "select all_repo_group_name from tall_repo_groups order by 1",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "all",
+          "value": "all"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "repogroup",
+        "options": [],
+        "query": "select all_repo_group_value from tall_repo_groups where all_repo_group_name = '[[repogroup_name]]'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "<h1 id=\"dashboard-header\">TiKV new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>",
+          "value": "<h1 id=\"dashboard-header\">TiKV new PRs dashboard</h1>\n<p>Links:</p>\n<ul>\n<li>Metric <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/new_prs.sql\" target=\"_blank\">SQL file</a>.</li>\n<li>TSDB <a href=\"https://github.com/cncf/devstats/blob/master/metrics/shared/metrics.yaml\" target=\"_blank\">series definition</a>. Search for <code>new_prs</code></li>\n<li>Grafana dashboard <a href=\"https://github.com/cncf/devstats/blob/master/grafana/dashboards/tikv/new-prs.json\" target=\"_blank\">JSON</a>.</li>\n</ul>\n<h1 id=\"description\">Description</h1>\n<ul>\n<li>This dashboard shows the number of new PRs opened in a given repository group or in all repository groups.</li>\n<li>Selecting period (for example week) means that dashboard will count opened PRs in those periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/periods.md\" target=\"_blank\">here</a> for more informations about periods.</li>\n<li>See <a href=\"https://github.com/cncf/devstats/blob/master/docs/repository_groups.md\" target=\"_blank\">here</a> for more informations about repository groups.</li>\n</ul>"
+        },
+        "datasource": "psql",
+        "definition": "",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "docs",
+        "options": [],
+        "query": "select value_s from gha_vars where name = 'new_prs_docs_html'",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": true,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-90d",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "PRs Opened in Repository Groups",
+  "uid": "15",
+  "version": 7
+}

--- a/configs/prod/grafana/pingcap/custom_sqlite.sql
+++ b/configs/prod/grafana/pingcap/custom_sqlite.sql
@@ -109,7 +109,9 @@ set
   )
 where
   slug in (
-    'new-prs-in-repository-groups',
+    'prs-opened-in-repository-groups',
+    'prs-merged-in-repository-groups',
+    'prs-closed-in-repository-groups',
     'open-pr-age-by-repository-group',
     'opened-to-merged',
     'pr-reviews-by-contributor',
@@ -117,7 +119,6 @@ where
     'prs-approval-repository-groups',
     'prs-authors-repository-groups',
     'prs-authors-table',
-    'prs-merged-repository-groups',
     'prs-mergers-table',
     'time-to-merge-in-repository-groups'
   )

--- a/configs/prod/grafana/tikv/custom_sqlite.sql
+++ b/configs/prod/grafana/tikv/custom_sqlite.sql
@@ -109,7 +109,9 @@ set
   )
 where
   slug in (
-    'new-prs-in-repository-groups',
+    'prs-opened-in-repository-groups',
+    'prs-merged-in-repository-groups',
+    'prs-closed-in-repository-groups',
     'open-pr-age-by-repository-group',
     'opened-to-merged',
     'pr-reviews-by-contributor',
@@ -117,7 +119,6 @@ where
     'prs-approval-repository-groups',
     'prs-authors-repository-groups',
     'prs-authors-table',
-    'prs-merged-repository-groups',
     'prs-mergers-table',
     'time-to-merge-in-repository-groups'
   )

--- a/deployments/helms/dev/values.yaml
+++ b/deployments/helms/dev/values.yaml
@@ -31,7 +31,7 @@ waitForPostgres: 15
 
 # Grafana configurations.
 grafanaCommand: 'grafana_start.sh'
-grafanaImage: 'miniantdev/devstats-grafana-dev:0.2.7.beta.4'
+grafanaImage: 'miniantdev/devstats-grafana-dev:0.2.7'
 grafanaMaxSurge: 1
 grafanaMaxUnavailable: 1
 grafanaNReplicas: 1
@@ -48,7 +48,7 @@ limitsGrafanasMemory: '8Gi'
 useGrafanasResourcesLimits: 1
 
 # Provision configurations.
-provisionImage: 'miniantdev/devstats-dev:0.2.7.beta.4'
+provisionImage: 'miniantdev/devstats-dev:0.2.7'
 projectsFile: 'projects.yaml'
 provisionCommand: './devel/deploy_all.sh'
 provisionPodName: devstats-provision
@@ -78,7 +78,7 @@ usePostgresResourcesLimits: 1
 
 # Cron sync jobs configurations.
 syncCommand: devstats
-syncImage: 'miniantdev/devstats-minimal-dev:0.2.7.beta.4'
+syncImage: 'miniantdev/devstats-minimal-dev:0.2.7'
 syncPodName: devstats
 syncRestartPolicy: Never
 concurrencyPolicy: Forbid
@@ -91,7 +91,7 @@ requestsCronsMemory: '2Gi'
 useCronsResourcesLimits: 1
 
 # Execute Pod configurations.
-executeImage: 'miniantdev/devstats-minimal-dev:0.2.7.beta.4'
+executeImage: 'miniantdev/devstats-minimal-dev:0.2.7'
 executePodName: 'devstats-execute'
 executeTargetProject: 'pingcap'
 executeCommand: 'sleep'

--- a/deployments/helms/dev/values.yaml
+++ b/deployments/helms/dev/values.yaml
@@ -91,7 +91,7 @@ requestsCronsMemory: '2Gi'
 useCronsResourcesLimits: 1
 
 # Execute Pod configurations.
-executeImage: 'miniantdev/devstats-minimal-dev:0.2.7.beta.1'
+executeImage: 'miniantdev/devstats-minimal-dev:0.2.7.beta.2'
 executePodName: 'devstats-execute'
 executeTargetProject: 'pingcap'
 executeCommand: 'sleep'

--- a/deployments/helms/dev/values.yaml
+++ b/deployments/helms/dev/values.yaml
@@ -31,7 +31,7 @@ waitForPostgres: 15
 
 # Grafana configurations.
 grafanaCommand: 'grafana_start.sh'
-grafanaImage: 'miniantdev/devstats-grafana-dev:0.2.7.beta.1'
+grafanaImage: 'miniantdev/devstats-grafana-dev:0.2.7.beta.4'
 grafanaMaxSurge: 1
 grafanaMaxUnavailable: 1
 grafanaNReplicas: 1
@@ -48,7 +48,7 @@ limitsGrafanasMemory: '8Gi'
 useGrafanasResourcesLimits: 1
 
 # Provision configurations.
-provisionImage: 'miniantdev/devstats-dev:0.2.7.beta.1'
+provisionImage: 'miniantdev/devstats-dev:0.2.7.beta.4'
 projectsFile: 'projects.yaml'
 provisionCommand: './devel/deploy_all.sh'
 provisionPodName: devstats-provision
@@ -78,7 +78,7 @@ usePostgresResourcesLimits: 1
 
 # Cron sync jobs configurations.
 syncCommand: devstats
-syncImage: 'miniantdev/devstats-minimal-dev:0.2.7.beta.1'
+syncImage: 'miniantdev/devstats-minimal-dev:0.2.7.beta.4'
 syncPodName: devstats
 syncRestartPolicy: Never
 concurrencyPolicy: Forbid
@@ -91,7 +91,7 @@ requestsCronsMemory: '2Gi'
 useCronsResourcesLimits: 1
 
 # Execute Pod configurations.
-executeImage: 'miniantdev/devstats-minimal-dev:0.2.7.beta.3'
+executeImage: 'miniantdev/devstats-minimal-dev:0.2.7.beta.4'
 executePodName: 'devstats-execute'
 executeTargetProject: 'pingcap'
 executeCommand: 'sleep'

--- a/deployments/helms/dev/values.yaml
+++ b/deployments/helms/dev/values.yaml
@@ -31,7 +31,7 @@ waitForPostgres: 15
 
 # Grafana configurations.
 grafanaCommand: 'grafana_start.sh'
-grafanaImage: 'miniantdev/devstats-grafana-dev:0.2.6'
+grafanaImage: 'miniantdev/devstats-grafana-dev:0.2.7.beta.1'
 grafanaMaxSurge: 1
 grafanaMaxUnavailable: 1
 grafanaNReplicas: 1
@@ -48,7 +48,7 @@ limitsGrafanasMemory: '8Gi'
 useGrafanasResourcesLimits: 1
 
 # Provision configurations.
-provisionImage: 'miniantdev/devstats-dev:0.2.6'
+provisionImage: 'miniantdev/devstats-dev:0.2.7.beta.1'
 projectsFile: 'projects.yaml'
 provisionCommand: './devel/deploy_all.sh'
 provisionPodName: devstats-provision
@@ -78,7 +78,7 @@ usePostgresResourcesLimits: 1
 
 # Cron sync jobs configurations.
 syncCommand: devstats
-syncImage: 'miniantdev/devstats-minimal-dev:0.2.6'
+syncImage: 'miniantdev/devstats-minimal-dev:0.2.7.beta.1'
 syncPodName: devstats
 syncRestartPolicy: Never
 concurrencyPolicy: Forbid
@@ -91,7 +91,7 @@ requestsCronsMemory: '2Gi'
 useCronsResourcesLimits: 1
 
 # Execute Pod configurations.
-executeImage: 'miniantdev/devstats-minimal-dev:0.2.6'
+executeImage: 'miniantdev/devstats-minimal-dev:0.2.7.beta.1'
 executePodName: 'devstats-execute'
 executeTargetProject: 'pingcap'
 executeCommand: 'sleep'

--- a/deployments/helms/dev/values.yaml
+++ b/deployments/helms/dev/values.yaml
@@ -91,7 +91,7 @@ requestsCronsMemory: '2Gi'
 useCronsResourcesLimits: 1
 
 # Execute Pod configurations.
-executeImage: 'miniantdev/devstats-minimal-dev:0.2.7.beta.2'
+executeImage: 'miniantdev/devstats-minimal-dev:0.2.7.beta.3'
 executePodName: 'devstats-execute'
 executeTargetProject: 'pingcap'
 executeCommand: 'sleep'

--- a/deployments/helms/prod/values.yaml
+++ b/deployments/helms/prod/values.yaml
@@ -32,7 +32,7 @@ waitForPostgres: 15
 
 # Grafana configurations.
 grafanaCommand: 'grafana_start.sh'
-grafanaImage: 'miniantdev/devstats-grafana-prod:0.2.6'
+grafanaImage: 'miniantdev/devstats-grafana-prod:0.2.7'
 grafanaMaxSurge: 1
 grafanaMaxUnavailable: 1
 grafanaNReplicas: 1
@@ -49,7 +49,7 @@ limitsGrafanasMemory: '8Gi'
 useGrafanasResourcesLimits: 1
 
 # Provision configurations.
-provisionImage: 'miniantdev/devstats-prod:0.2.6'
+provisionImage: 'miniantdev/devstats-prod:0.2.7'
 projectsFile: 'projects.yaml'
 provisionCommand: './devel/deploy_all.sh'
 provisionPodName: devstats-provision
@@ -79,7 +79,7 @@ usePostgresResourcesLimits: 1
 
 # Cron sync jobs configurations.
 syncCommand: devstats
-syncImage: 'miniantdev/devstats-minimal-prod:0.2.6'
+syncImage: 'miniantdev/devstats-minimal-prod:0.2.7'
 syncPodName: devstats
 syncRestartPolicy: Never
 concurrencyPolicy: Forbid
@@ -92,7 +92,7 @@ requestsCronsMemory: '2Gi'
 useCronsResourcesLimits: 1
 
 # Execute Pod configurations.
-executeImage: 'miniantdev/devstats-minimal-prod:0.2.6'
+executeImage: 'miniantdev/devstats-minimal-prod:0.2.7'
 executePodName: 'devstats-execute'
 executeTargetProject: 'tikv'
 executeCommand: 'sleep'


### PR DESCRIPTION
- Add company group for opened/closed/merged PR metrics
- Exclude the bot's activity for new/episodic contributors metrics
- Add new dashboard "[PRs Closed in Repository Groups](https://tikv-devstats-dev.tidb.io/d/pr-closed/prs-closed-in-repository-groups?orgId=1)"
- Improve [PRs Opened in Repository Groups](https://pingcap-devstats-dev.tidb.io/d/15/prs-opened-in-repository-groups?orgId=1)
- Improve [PRs closed in Repository Groups](https://tikv-devstats-dev.tidb.io/d/pr-closed/prs-closed-in-repository-groups?orgId=1)
- Fix the axes-y unit for [Opened to Merged](https://tikv-devstats-dev.tidb.io/d/16/opened-to-merged?orgId=1)